### PR TITLE
configure.ac: Set `foreign` option to fix build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,7 @@ AC_CONFIG_AUX_DIR([build])
 AC_CONFIG_MACRO_DIR([build])
 AC_CONFIG_HEADERS([config.h sigc++config.h])
 
-AM_INIT_AUTOMAKE([1.9 -Wno-portability check-news no-dist-gzip dist-xz tar-ustar no-define nostdinc])
+AM_INIT_AUTOMAKE([1.9 -Wno-portability check-news no-dist-gzip dist-xz tar-ustar no-define nostdinc foreign])
 # Support silent build rules.
 # Disable by either passing --disable-silent-rules to configure or passing V=1 to make.
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])


### PR DESCRIPTION
Without the `foreign` option, automake requires a README file, which no
longer exists.

	Makefile.am: error: required file './README' not found

Fixes: 8a0cb176 ("README: Rename to README.md and reformat as markdown")