### PR TITLE
Empty connections can be safely copied now

### DIFF
--- a/sigc++/weak_raw_ptr.h
+++ b/sigc++/weak_raw_ptr.h
@@ -50,7 +50,8 @@ struct weak_raw_ptr : public sigc::notifiable
   inline weak_raw_ptr(const weak_raw_ptr& src) noexcept
   : p_(src.p_)
   {
-    p_->add_destroy_notify_callback(this, &notify_object_invalidated);
+    if (p_)
+      p_->add_destroy_notify_callback(this, &notify_object_invalidated);
   }
 
   inline weak_raw_ptr& operator=(const weak_raw_ptr& src) noexcept
@@ -60,7 +61,9 @@ struct weak_raw_ptr : public sigc::notifiable
     }
 
     p_ = src.p_;
-    p_->add_destroy_notify_callback(this, &notify_object_invalidated);
+    
+    if (p_)
+      p_->add_destroy_notify_callback(this, &notify_object_invalidated);
 
     return *this;
   }


### PR DESCRIPTION
Copy constructor and `operator=` could fail if `src` was empty.
```
sigc::connection con1;
sigc::connection con2(con1); // failed
```
```
sigc::connection con3;
sigc::connection con4;
con3 = con4; // failed
```