### PR TITLE
Github Actions: Use --enable-warnings=fatal

### DIFF
--- a/.github/workflows/autotools-clang-5.yml
+++ b/.github/workflows/autotools-clang-5.yml
@@ -14,7 +14,7 @@ jobs:
         sudo apt update
         sudo apt install mm-common clang-5.0
         export CXX=clang++-5.0
-        ./autogen.sh
+        ./autogen.sh --enable-warnings=fatal
         ./configure
         make
     - name: Test

--- a/.github/workflows/autotools-clang-6.yml
+++ b/.github/workflows/autotools-clang-6.yml
@@ -14,7 +14,7 @@ jobs:
         sudo apt update
         sudo apt install mm-common clang-6.0
         export CXX=clang++-6.0
-        ./autogen.sh
+        ./autogen.sh --enable-warnings=fatal
         ./configure
         make
     - name: Test

--- a/.github/workflows/autotools-clang-7.yml
+++ b/.github/workflows/autotools-clang-7.yml
@@ -14,7 +14,7 @@ jobs:
         sudo apt update
         sudo apt install mm-common clang-7
         export CXX=clang++-7
-        ./autogen.sh
+        ./autogen.sh --enable-warnings=fatal
         ./configure
         make
     - name: Test

--- a/.github/workflows/autotools-clang-8.yml
+++ b/.github/workflows/autotools-clang-8.yml
@@ -15,7 +15,7 @@ jobs:
         sudo apt update
         sudo apt install mm-common clang-8
         export CXX=clang++-8
-        ./autogen.sh
+        ./autogen.sh --enable-warnings=fatal
         ./configure
         make
     - name: Test

--- a/.github/workflows/autotools-gcc-7.yml
+++ b/.github/workflows/autotools-gcc-7.yml
@@ -14,7 +14,7 @@ jobs:
         sudo apt update
         sudo apt install mm-common g++-7
         export CXX=g++-7
-        ./autogen.sh
+        ./autogen.sh --enable-warnings=fatal
         ./configure
         make
     - name: Test

--- a/.github/workflows/autotools-gcc-8.yml
+++ b/.github/workflows/autotools-gcc-8.yml
@@ -14,7 +14,7 @@ jobs:
         sudo apt update
         sudo apt install mm-common g++-8
         export CXX=g++-8
-        ./autogen.sh
+        ./autogen.sh --enable-warnings=fatal
         ./configure
         make
     - name: Test

--- a/.github/workflows/autotools-gcc-9.yml
+++ b/.github/workflows/autotools-gcc-9.yml
@@ -15,7 +15,7 @@ jobs:
         sudo apt update
         sudo apt install mm-common g++-9
         export CXX=g++-9
-        ./autogen.sh
+        ./autogen.sh --enable-warnings=fatal
         ./configure
         make
     - name: Test


### PR DESCRIPTION
This enables more warnings and makes the build fail if they happen.