### PR TITLE
MSVC build: Add default warning flags to CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,14 +30,15 @@ project (sigc++)
 
 set( CMAKE_CXX_STANDARD 17 )
 
-# Turn on warnings for MSVC
-if (MSVC)
-    # Remove the CMake default of /W3 because when you add /W4, MSVC will complain
-    # about two warning level flags
+# Turn on warnings for MSVC. Remove the CMake default of /W3 because when you
+# add /W4, MSVC will complain about two warning level flags. This default
+# changed at CMake 3.15 (see 
+# https://cmake.org/cmake/help/v3.15/policy/CMP0092.html#policy:CMP0092 for
+# more details)
+ if (MSVC AND CMAKE_VERSION VERSION_LESS "13.15")
     string(REGEX REPLACE "(^|[ \t])/W[0-9]($|[ \t])" "\\1\\2" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
     string(REGEX REPLACE "(^|[ \t])/W[0-9]($|[ \t])" "\\1\\2" CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS}")
-elseif(CXX_COMPILER_ID)
 endif()
 
 # Add compiler warning flags & turn warnings into errors

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,23 @@ project (sigc++)
 
 set( CMAKE_CXX_STANDARD 17 )
 
+# Turn on warnings for MSVC
+if (MSVC)
+    # Remove the CMake default of /W3 because when you add /W4, MSVC will complain
+    # about two warning level flags
+    string(REGEX REPLACE "(^|[ \t])/W[0-9]($|[ \t])" "\\1\\2" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+    string(REGEX REPLACE "(^|[ \t])/W[0-9]($|[ \t])" "\\1\\2" CMAKE_CXX_FLAGS
+    "${CMAKE_CXX_FLAGS}")
+elseif(CXX_COMPILER_ID)
+endif()
+
+# Add compiler warning flags & turn warnings into errors
+add_compile_options(
+    "$<$<OR:$<CXX_COMPILER_ID:MSVC>,$<C_COMPILER_ID:MSVC>>:/W4;/WX>"
+    "$<$<OR:$<CXX_COMPILER_ID:GNU>,$<C_COMPILER_ID:GNU>>:-pedantic;-Wall;-Wextra;-Wsuggest-override;-Wshadow;-Wzero-as-null-pointer-constant;-Wformat-security>"
+    "$<$<OR:$<CXX_COMPILER_ID:Clang>,$<C_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<C_COMPILER_ID:AppleClang>>:-pedantic;-Wall;-Wextra;-Wshadow;-Wzero-as-null-pointer-constant;-Wformat-security>"
+)
+
 set (PROJECT_SOURCE_DIR "${sigc++_SOURCE_DIR}/sigc++")
 
 include_directories (${sigc++_SOURCE_DIR})

--- a/sigc++/tuple-utils/tuple_end.h
+++ b/sigc++/tuple-utils/tuple_end.h
@@ -56,6 +56,7 @@ tuple_end(T&& t) {
   static_assert(len <= size, "The tuple size must be less than or equal to the length.");
 
   if constexpr(len == 0) {
+    // Prevent 'unreferenced formal parameter' warning from MSVC by 'using' t
     static_cast<void>(t);
     // Recursive calls to tuple_cdr() would result in this eventually,
     // but this avoids the extra work:

--- a/sigc++/tuple-utils/tuple_end.h
+++ b/sigc++/tuple-utils/tuple_end.h
@@ -56,6 +56,7 @@ tuple_end(T&& t) {
   static_assert(len <= size, "The tuple size must be less than or equal to the length.");
 
   if constexpr(len == 0) {
+    static_cast<void>(t);
     // Recursive calls to tuple_cdr() would result in this eventually,
     // but this avoids the extra work:
     return std::tuple<>();

--- a/sigc++/tuple-utils/tuple_for_each.h
+++ b/sigc++/tuple-utils/tuple_for_each.h
@@ -104,6 +104,7 @@ tuple_for_each(T&& t, T_extras&&... extras)
     detail::tuple_for_each_impl<T_visitor, size, T_extras...>::tuple_for_each(
       std::forward<T>(t), std::forward<T_extras>(extras)...);
   } else {
+    // Prevent 'unreferenced formal parameter' warning from MSVC by 'using' t
     static_cast<void>(t);
   }
 }

--- a/sigc++/tuple-utils/tuple_for_each.h
+++ b/sigc++/tuple-utils/tuple_for_each.h
@@ -99,13 +99,11 @@ tuple_for_each(T&& t, T_extras&&... extras)
   // We use std::decay_t<> because tuple_size is not defined for references.
   constexpr auto size = std::tuple_size<std::decay_t<T>>::value;
 
-  if (size == 0)
+  if constexpr (size != 0)
   {
-    return;
+    detail::tuple_for_each_impl<T_visitor, size, T_extras...>::tuple_for_each(
+      std::forward<T>(t), std::forward<T_extras>(extras)...);
   }
-
-  detail::tuple_for_each_impl<T_visitor, size, T_extras...>::tuple_for_each(
-    std::forward<T>(t), std::forward<T_extras>(extras)...);
 }
 
 } // namespace internal

--- a/sigc++/tuple-utils/tuple_for_each.h
+++ b/sigc++/tuple-utils/tuple_for_each.h
@@ -103,6 +103,8 @@ tuple_for_each(T&& t, T_extras&&... extras)
   {
     detail::tuple_for_each_impl<T_visitor, size, T_extras...>::tuple_for_each(
       std::forward<T>(t), std::forward<T_extras>(extras)...);
+  } else {
+    static_cast<void>(t);
   }
 }
 

--- a/sigc++/tuple-utils/tuple_transform_each.h
+++ b/sigc++/tuple-utils/tuple_transform_each.h
@@ -35,6 +35,8 @@ struct tuple_transform_each_impl {
   static decltype(auto)
   tuple_transform_each(T_current&& t, T_original& t_original) {
     if constexpr(size_from_index == 0) {
+    // Prevent 'unreferenced formal parameter' warning from MSVC by 'using'
+    // t_original
       static_cast<void>(t_original);
       //Do nothing because the tuple has no elements.
       return std::forward<T_current>(t);

--- a/sigc++/tuple-utils/tuple_transform_each.h
+++ b/sigc++/tuple-utils/tuple_transform_each.h
@@ -35,6 +35,7 @@ struct tuple_transform_each_impl {
   static decltype(auto)
   tuple_transform_each(T_current&& t, T_original& t_original) {
     if constexpr(size_from_index == 0) {
+      static_cast<void>(t_original);
       //Do nothing because the tuple has no elements.
       return std::forward<T_current>(t);
     } else { //TODO: Should this compile without using else to contain the alternative code?

--- a/sigc++/visit_each.h
+++ b/sigc++/visit_each.h
@@ -48,6 +48,7 @@ struct limit_trackable_target
     if constexpr(is_base_of_or_same_v<sigc::trackable, T_type>) {
         std::invoke(action_, type);
     } else {
+    // Prevent 'unreferenced formal parameter' warning from MSVC by 'using' type
       static_cast<void>(type);
     }
   }

--- a/sigc++/visit_each.h
+++ b/sigc++/visit_each.h
@@ -47,6 +47,8 @@ struct limit_trackable_target
     //Only call action_() if T_Type derives from trackable.
     if constexpr(is_base_of_or_same_v<sigc::trackable, T_type>) {
         std::invoke(action_, type);
+    } else {
+      static_cast<void>(type);
     }
   }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,10 @@ function (add_sigcpp_test TEST_SOURCE_FILE)
         add_test (NAME ${test_name}
           # Help MSVC to find the library that the tests should link against.
           COMMAND ${CMAKE_COMMAND} -E env "PATH=$<TARGET_FILE_DIR:sigc-${SIGCXX_API_VERSION}>;$ENV{PATH}" $<TARGET_FILE:${test_name}>)
+
+  if (MSVC AND test_name MATCHES "^(test_retype_return|test_signal)$")
+    target_compile_options(${test_name} PRIVATE "/wd4244")
+  endif()
 endfunction (add_sigcpp_test)
 
 foreach (test_file ${TEST_SOURCE_FILES})


### PR DESCRIPTION
This pull request adds warning flags '/W4 /WX' to the MSVC build created with CMake from the CMakeLists.txt files in the build. This also includes code to remove the '/W3' warning level flag that CMake has in its MSVC compiler flag defaults.

There is also code to set the default GCC/Clang compiler flags. These defaults have been taken from the configure.ac in the build.