### PR TITLE
test_limit_reference: Avoid virtual-move-assign warning

### DIFF
--- a/tests/test_limit_reference.cc
+++ b/tests/test_limit_reference.cc
@@ -11,6 +11,11 @@ std::ostringstream result_stream;
 
 class Base : virtual public sigc::trackable
 {
+public:
+  Base() {}
+
+  Base(Base&& src) = delete;
+  Base& operator=(Base&& src) = delete;
 };
 
 class Base2


### PR DESCRIPTION
Explicitly implement Bases's move constructor because the defaulted one
would call non-trivial assignment operators in the virtual bases.

And implement the default constructor too, because it is not
generated automatically if we implement the move constructor.

This avoids this compiler warning, at least with g++ 9.2:

test_limit_reference.cc:12:7: error: defaulted move assignment for ‘{anonymous}::Base’ calls a non-trivial move assignment operator for virtual base ‘sigc::trackable’ [-Werror=virtual-move-assign]
   12 | class Base : virtual public sigc::trackable
      |       ^~~~
test_limit_reference.cc:22:7: error: defaulted move assignment for ‘{anonymous}::Derived’ calls a non-trivial move assignment operator for virtual base ‘{anonymous}::Base’ [-Werror=virtual-move-assign]
   22 | class Derived : virtual public Base, public Base2

It would be nice if this test had a comment saying what it is testing.