### PR TITLE
GitHub Actions CI: autotools-clang-8: Don't try to use Ubuntu 19.10

### DIFF
--- a/.github/workflows/autotools-clang-8.yml
+++ b/.github/workflows/autotools-clang-8.yml
@@ -9,7 +9,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: docker://ubuntu:19.10
     - name: Build
       run: |
         sudo apt update


### PR DESCRIPTION
The uses: line was actually a separate step that didn't influence the
following step. Ubuntu 18.04 (what GitHub actions uses for
"ubuntu-latest") actually has clang-8 anyway.