### PR TITLE
GitHub Actions CI: Specify CXX before make distcheck

### DIFF
--- a/.github/workflows/autotools-clang-5.yml
+++ b/.github/workflows/autotools-clang-5.yml
@@ -20,4 +20,7 @@ jobs:
     - name: Test
       run: make check
     - name: Distcheck
-      run: make distcheck
+      run: |
+        # distcheck runs configure again so we need to specify CXX again.
+        export CXX=clang++-5.0
+        make distcheck

--- a/.github/workflows/autotools-clang-6.yml
+++ b/.github/workflows/autotools-clang-6.yml
@@ -20,4 +20,7 @@ jobs:
     - name: Test
       run: make check
     - name: Distcheck
-      run: make distcheck
+      run: |
+        # distcheck runs configure again so we need to specify CXX again.
+        export CXX=clang++-6.0
+        make distcheck

--- a/.github/workflows/autotools-clang-7.yml
+++ b/.github/workflows/autotools-clang-7.yml
@@ -20,4 +20,7 @@ jobs:
     - name: Test
       run: make check
     - name: Distcheck
-      run: make distcheck
+      run: |
+        # distcheck runs configure again so we need to specify CXX again.
+        export CXX=clang++-7
+        make distcheck

--- a/.github/workflows/autotools-clang-8.yml
+++ b/.github/workflows/autotools-clang-8.yml
@@ -20,4 +20,7 @@ jobs:
     - name: Test
       run: make check
     - name: Distcheck
-      run: make distcheck
+      run: |
+        # distcheck runs configure again so we need to specify CXX again.
+        export CXX=clang++-8
+        make distcheck

--- a/.github/workflows/autotools-clang-9.yml
+++ b/.github/workflows/autotools-clang-9.yml
@@ -21,4 +21,7 @@ jobs:
     - name: Test
       run: make check
     - name: Distcheck
-      run: make distcheck
+      run: |
+        # distcheck runs configure again so we need to specify CXX again.
+        export CXX=clang++-9
+        make distcheck

--- a/.github/workflows/autotools-gcc-7.yml
+++ b/.github/workflows/autotools-gcc-7.yml
@@ -20,4 +20,7 @@ jobs:
     - name: Test
       run: make check
     - name: Distcheck
-      run: make distcheck
+      run: |
+        # distcheck runs configure again so we need to specify CXX again.
+        export CXX=g++-7
+        make distcheck

--- a/.github/workflows/autotools-gcc-8.yml
+++ b/.github/workflows/autotools-gcc-8.yml
@@ -20,4 +20,7 @@ jobs:
     - name: Test
       run: make check
     - name: Distcheck
-      run: make distcheck
+      run: |
+        # distcheck runs configure again so we need to specify CXX again.
+        export CXX=g++-8
+        make distcheck

--- a/.github/workflows/autotools-gcc-9.yml
+++ b/.github/workflows/autotools-gcc-9.yml
@@ -21,4 +21,7 @@ jobs:
     - name: Test
       run: make check
     - name: Distcheck
-      run: make distcheck
+      run: |
+        # distcheck runs configure again so we need to specify CXX again.
+        export CXX=g++-9
+        make distcheck


### PR DESCRIPTION
As in the build step. Otherwise, the distcheck's configure run will
just pick up the default compiler again.