### PR TITLE
CI: GitHub actions: check format

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,20 @@
+name: "CI: Check Code Formatting"
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Check Code Formatting
+      run: |
+        # Prevent blocking the install on a question during configuring of tzdata.
+        export ENV DEBIAN_FRONTEND=noninteractive
+        sudo apt update
+        sudo apt install build-essential mm-common clang-format-10 --yes
+        sudo ln -sf /usr/bin/clang-format-10 /usr/bin/clang-format
+        ./autogen.sh --enable-warnings=fatal
+        make check-format

--- a/Makefile.am
+++ b/Makefile.am
@@ -67,3 +67,9 @@ include $(top_srcdir)/build/dist-changelog.am
 # clang-format versions via a bash alias.)
 format:
 	clang-format -i `find . -name "*.h" -or -name "*.cc"`
+
+# Run clang-format over all files, and fail if they are not formatted correctly.
+# (This requires clang-format 10, which has the --dry-run and --Werror
+# command-line arguments.)
+check-format:
+	clang-format --dry-run --Werror `find . -name "*.h" -or -name "*.cc"`

--- a/sigc++/sigc++.h
+++ b/sigc++/sigc++.h
@@ -36,7 +36,8 @@
  * See also the
  * <a href="https://developer.gnome.org/libsigc++-tutorial/stable/">libsigc++ tutorial</a>,
  * the <a href="https://libsigcplusplus.github.io/libsigcplusplus/">libsigc++ website</a>, and
- * the <a href="https://developer.gnome.org/gtkmm-tutorial/unstable/chapter-signals.html">Signals appendix of the Programming with gtkmm book</a>.
+ * the <a href="https://developer.gnome.org/gtkmm-tutorial/unstable/chapter-signals.html">Signals
+ * appendix of the Programming with gtkmm book</a>.
  *
  * @section features Features
  *

--- a/sigc++config.h.in
+++ b/sigc++config.h.in
@@ -13,20 +13,20 @@
 
 /* Detect Win32 platform */
 #ifdef _WIN32
-# if defined(_MSC_VER)
-#  define SIGC_MSC 1
-#  define SIGC_WIN32 1
-#  define SIGC_DLL 1
-# elif defined(__CYGWIN__)
-#  define SIGC_CONFIGURE 1
-# elif defined(__MINGW32__)
-#  define SIGC_WIN32 1
-#  define SIGC_CONFIGURE 1
-# else
-#  error "libsigc++ config: Unknown win32 architecture (send me gcc --dumpspecs or equiv)"
-# endif
+#if defined(_MSC_VER)
+#define SIGC_MSC 1
+#define SIGC_WIN32 1
+#define SIGC_DLL 1
+#elif defined(__CYGWIN__)
+#define SIGC_CONFIGURE 1
+#elif defined(__MINGW32__)
+#define SIGC_WIN32 1
+#define SIGC_CONFIGURE 1
+#else
+#error "libsigc++ config: Unknown win32 architecture (send me gcc --dumpspecs or equiv)"
+#endif
 #else /* !_WIN32 */
-# define SIGC_CONFIGURE 1
+#define SIGC_CONFIGURE 1
 #endif /* !_WIN32 */
 
 #ifdef SIGC_MSC
@@ -42,9 +42,9 @@
  * seems to have no adverse effects, so that seems like a good enough
  * solution for now.
  */
-# pragma warning(disable:4251)
+#pragma warning(disable : 4251)
 
-#if (_MSC_VER < 1900) && !defined (noexcept)
+#if (_MSC_VER < 1900) && !defined(noexcept)
 #define _ALLOW_KEYWORD_MACROS 1
 #define noexcept _NOEXCEPT
 #endif
@@ -54,13 +54,13 @@
 #endif /* !SIGC_MSC */
 
 #ifdef SIGC_DLL
-# if defined(SIGC_BUILD) && defined(_WINDLL)
-#  define SIGC_API __declspec(dllexport)
-# elif !defined(SIGC_BUILD)
-#  define SIGC_API __declspec(dllimport)
-# else
-#  define SIGC_API
-# endif
+#if defined(SIGC_BUILD) && defined(_WINDLL)
+#define SIGC_API __declspec(dllexport)
+#elif !defined(SIGC_BUILD)
+#define SIGC_API __declspec(dllimport)
+#else
+#define SIGC_API
+#endif
 #else /* !SIGC_DLL */
-# define SIGC_API
+#define SIGC_API
 #endif /* !SIGC_DLL */

--- a/sigc++config.h.meson
+++ b/sigc++config.h.meson
@@ -16,20 +16,20 @@
 
 /* Detect Win32 platform */
 #ifdef _WIN32
-# if defined(_MSC_VER)
-#  define SIGC_MSC 1
-#  define SIGC_WIN32 1
-#  define SIGC_DLL 1
-# elif defined(__CYGWIN__)
-#  define SIGC_CONFIGURE 1
-# elif defined(__MINGW32__)
-#  define SIGC_WIN32 1
-#  define SIGC_CONFIGURE 1
-# else
-#  error "libsigc++ config: Unknown win32 architecture (send me gcc --dumpspecs or equiv)"
-# endif
+#if defined(_MSC_VER)
+#define SIGC_MSC 1
+#define SIGC_WIN32 1
+#define SIGC_DLL 1
+#elif defined(__CYGWIN__)
+#define SIGC_CONFIGURE 1
+#elif defined(__MINGW32__)
+#define SIGC_WIN32 1
+#define SIGC_CONFIGURE 1
+#else
+#error "libsigc++ config: Unknown win32 architecture (send me gcc --dumpspecs or equiv)"
+#endif
 #else /* !_WIN32 */
-# define SIGC_CONFIGURE 1
+#define SIGC_CONFIGURE 1
 #endif /* !_WIN32 */
 
 #ifdef SIGC_MSC
@@ -45,9 +45,9 @@
  * seems to have no adverse effects, so that seems like a good enough
  * solution for now.
  */
-# pragma warning(disable:4251)
+#pragma warning(disable : 4251)
 
-#if (_MSC_VER < 1900) && !defined (noexcept)
+#if (_MSC_VER < 1900) && !defined(noexcept)
 #define _ALLOW_KEYWORD_MACROS 1
 #define noexcept _NOEXCEPT
 #endif
@@ -57,15 +57,15 @@
 #endif /* !SIGC_MSC */
 
 #ifdef SIGC_DLL
-# if defined(SIGC_BUILD) && defined(_WINDLL)
-#  define SIGC_API __declspec(dllexport)
-# elif !defined(SIGC_BUILD)
-#  define SIGC_API __declspec(dllimport)
-# else
-#  define SIGC_API
-# endif
+#if defined(SIGC_BUILD) && defined(_WINDLL)
+#define SIGC_API __declspec(dllexport)
+#elif !defined(SIGC_BUILD)
+#define SIGC_API __declspec(dllimport)
+#else
+#define SIGC_API
+#endif
 #else /* !SIGC_DLL */
-# define SIGC_API
+#define SIGC_API
 #endif /* !SIGC_DLL */
 
 #endif /* !SIGCXXCONFIG_H_INCLUDED */

--- a/tests/test_bind.cc
+++ b/tests/test_bind.cc
@@ -70,7 +70,7 @@ struct book : public sigc::trackable
   book& operator=(book&&) = delete;
 
   std::string& get_name() { return name_; }
-  operator std::string&() { return get_name(); }
+  operator std::string &() { return get_name(); }
 
 private:
   std::string name_;

--- a/tests/test_bind_refptr.cc
+++ b/tests/test_bind_refptr.cc
@@ -197,7 +197,8 @@ private:
 // If it would come after them it wouldn't be inlined.
 
 template<typename T_CppObject>
-inline T_CppObject* RefPtr<T_CppObject>::operator->() const
+inline T_CppObject*
+RefPtr<T_CppObject>::operator->() const
 {
   return pCppObject_;
 }

--- a/tests/test_cpp11_lambda.cc
+++ b/tests/test_cpp11_lambda.cc
@@ -88,7 +88,7 @@ egon(std::string& str)
 struct book : public sigc::trackable
 {
   explicit book(const std::string& name) : name_(name) {}
-  operator std::string&() { return name_; }
+  operator std::string &() { return name_; }
   std::string name_;
 };
 

--- a/tests/test_track_obj.cc
+++ b/tests/test_track_obj.cc
@@ -40,8 +40,8 @@ std::ostringstream result_stream;
 struct book : public sigc::trackable
 {
   explicit book(const std::string& name) : name_(name) {}
-  operator std::string&() { return name_; }
-  operator const std::string&() const { return name_; }
+  operator std::string &() { return name_; }
+  operator const std::string &() const { return name_; }
   std::string name_;
 };
 


### PR DESCRIPTION
This requires clang-format from clang 10, because it uses the new --dry-run and --Werror options. So it uses Ubuntu 20.04.