### PR TITLE
GitHub Actions CI: Remove extra configure calls

### DIFF
--- a/.github/workflows/autotools-clang-5.yml
+++ b/.github/workflows/autotools-clang-5.yml
@@ -15,7 +15,6 @@ jobs:
         sudo apt install mm-common clang-5.0
         export CXX=clang++-5.0
         ./autogen.sh --enable-warnings=fatal
-        ./configure
         make
     - name: Test
       run: make check

--- a/.github/workflows/autotools-clang-6.yml
+++ b/.github/workflows/autotools-clang-6.yml
@@ -15,7 +15,6 @@ jobs:
         sudo apt install mm-common clang-6.0
         export CXX=clang++-6.0
         ./autogen.sh --enable-warnings=fatal
-        ./configure
         make
     - name: Test
       run: make check

--- a/.github/workflows/autotools-clang-7.yml
+++ b/.github/workflows/autotools-clang-7.yml
@@ -15,7 +15,6 @@ jobs:
         sudo apt install mm-common clang-7
         export CXX=clang++-7
         ./autogen.sh --enable-warnings=fatal
-        ./configure
         make
     - name: Test
       run: make check

--- a/.github/workflows/autotools-clang-8.yml
+++ b/.github/workflows/autotools-clang-8.yml
@@ -15,7 +15,6 @@ jobs:
         sudo apt install mm-common clang-8
         export CXX=clang++-8
         ./autogen.sh --enable-warnings=fatal
-        ./configure
         make
     - name: Test
       run: make check

--- a/.github/workflows/autotools-clang-9.yml
+++ b/.github/workflows/autotools-clang-9.yml
@@ -16,7 +16,6 @@ jobs:
         apt install mm-common clang-9 --yes
         export CXX=clang++-9
         ./autogen.sh --enable-warnings=fatal
-        ./configure
         make
     - name: Test
       run: make check

--- a/.github/workflows/autotools-gcc-7.yml
+++ b/.github/workflows/autotools-gcc-7.yml
@@ -15,7 +15,6 @@ jobs:
         sudo apt install mm-common g++-7
         export CXX=g++-7
         ./autogen.sh --enable-warnings=fatal
-        ./configure
         make
     - name: Test
       run: make check

--- a/.github/workflows/autotools-gcc-8.yml
+++ b/.github/workflows/autotools-gcc-8.yml
@@ -15,7 +15,6 @@ jobs:
         sudo apt install mm-common g++-8
         export CXX=g++-8
         ./autogen.sh --enable-warnings=fatal
-        ./configure
         make
     - name: Test
       run: make check

--- a/.github/workflows/autotools-gcc-9.yml
+++ b/.github/workflows/autotools-gcc-9.yml
@@ -16,7 +16,6 @@ jobs:
         sudo apt install mm-common g++-9
         export CXX=g++-9
         ./autogen.sh --enable-warnings=fatal
-        ./configure
         make
     - name: Test
       run: make check


### PR DESCRIPTION
./autogen.sh already runs configure, passing the arguments.
This is why the builds didn't fail when there were compiler errors.