### PR TITLE
tests: Remove unused SIGC_CXX_TYPEOF alternative code

### DIFF
--- a/tests/test_compose.cc
+++ b/tests/test_compose.cc
@@ -31,25 +31,6 @@ struct set_void
 
 struct get
 {
-#ifdef SIGC_CXX_TYPEOF
-  bool operator()()
-  {
-    result_stream << "get() ";
-    return true;
-  }
-
-  int operator()(int i)
-  {
-    result_stream << "get(" << i << ") ";
-    return i * 2;
-  }
-
-  double operator()(int i, int j)
-  {
-    result_stream << "get(" << i << ", " << j << ") ";
-    return double(i) / double(j);
-  }
-#else
   double operator()()
   {
     result_stream << "get() ";
@@ -67,7 +48,6 @@ struct get
     result_stream << "get(" << i << ", " << j << ") ";
     return double(i) / double(j);
   }
-#endif
 };
 
 } // end anonymous namespace


### PR DESCRIPTION
This was apparently related to some long-since removed libsigc++ support
for a non-standard a gcc typeof() extension.
https://gcc.gnu.org/onlinedocs/gcc/Typeof.html