### PR TITLE
Fix Visual Studio builds via Meson (libsigc++-2.x)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -92,11 +92,9 @@ benchmark_dep = dependency('boost', modules: ['system', 'timer'],
                            version: '>=1.20.0', required: do_benchmark)
 can_benchmark = benchmark_dep.found()
 
-if is_msvc
-  # We must have Visual Studio 2017 15.7 or later...
-  assert(cpp_compiler.version().split('.')[0].to_int() >= 19 and \
-         cpp_compiler.version().split('.')[1].to_int() >= 15,
-         'Visual Studio 2017 15.7 or later is required')
+# We must have Visual Studio 2015 or later...
+if is_msvc and cpp_compiler.version().version_compare('<19')
+  error('Visual Studio 2015 or later is required')
 endif
 
 # Some dependencies are required only in maintainer mode and/or

--- a/sigc++/meson.build
+++ b/sigc++/meson.build
@@ -92,6 +92,13 @@ src_untracked_sigcxx = project_source_root / untracked_sigcxx
 
 handle_built_files = project_source_root / 'tools' / 'handle-built-files.py'
 
+extra_sigc_cppflags = []
+
+# Make sure we are exporting the symbols from the DLL
+if is_msvc
+  extra_sigc_cppflags += ['-DSIGC_BUILD', '-D_WINDLL']
+endif
+
 if maintainer_mode
 
   # Maintainer mode. Generate .h and .cc files from .m4 files in macros/ directories.
@@ -152,6 +159,7 @@ if maintainer_mode
   sigcxx_library = library(sigcxx_pcname,
     source_cc_files, built_cc_file_targets, built_h_file_targets,
     version: sigcxx_libversion,
+    cpp_args: extra_sigc_cppflags,
     include_directories: extra_include_dirs,
     dependencies: sigcxx_build_dep,
     install: true,
@@ -193,6 +201,7 @@ else # not maintainer_mode
   sigcxx_library = library(sigcxx_pcname,
     source_cc_files, untracked_built_cc_files,
     version: sigcxx_libversion,
+    cpp_args: extra_sigc_cppflags,
     include_directories: extra_include_dirs,
     dependencies: sigcxx_build_dep,
     install: true,


### PR DESCRIPTION
Hi,

These are the simple additions that are required for the Meson build system for libsigc++-2.x so that it may be used for Visual Studio builds, too.

With blessings, thank you!