### PR TITLE
Meson: More fixes for Windows builds

### DIFF
--- a/MSVC_NMake/build-rules-msvc.mak
+++ b/MSVC_NMake/build-rules-msvc.mak
@@ -31,6 +31,9 @@ $(LIBSIGC_LIB): $(LIBSIGC_DLL)
 {.}.rc{$(CFG)\$(PLAT)\libsigcpp\}.res:
 	rc /fo$@ $<
 
+{..\untracked\MSVC_NMake\}.rc{$(CFG)\$(PLAT)\libsigcpp\}.res:
+	rc /fo$@ $<
+
 # Rules for linking DLLs
 # Format is as follows (the mt command is needed for MSVC 2005/2008 builds):
 # $(dll_name_with_path): $(dependent_libs_files_objects_and_items)

--- a/MSVC_NMake/build-rules-msvc.mak
+++ b/MSVC_NMake/build-rules-msvc.mak
@@ -13,25 +13,25 @@
 # 	$(CC)|$(CXX) $(cflags) /Fo$(destdir) /c @<<
 # $<
 # <<
-{..\sigc++\}.cc{$(CFG)\$(PLAT)\libsigcpp\}.obj::
-	$(CXX) $(LIBSIGCPP_CFLAGS) /Fo$(CFG)\$(PLAT)\libsigcpp\ /c @<<
+{..\sigc++\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp\}.obj:
+	$(CXX) $(LIBSIGCPP_CFLAGS) /Fo$(@D)\ /Fd$(@D)\ /c @<<
 $<
 <<
 
-{..\sigc++\functors\}.cc{$(CFG)\$(PLAT)\libsigcpp\}.obj::
-	$(CXX) $(LIBSIGCPP_CFLAGS) /Fo$(CFG)\$(PLAT)\libsigcpp\ /c @<<
+{..\sigc++\functors\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp\}.obj:
+	$(CXX) $(LIBSIGCPP_CFLAGS) /Fo$(@D)\ /Fd$(@D)\  /c @<<
 $<
 <<
 
-$(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj: $(CFG)\$(PLAT)\libsigcpp-tests ..\tests\testutilities.cc
-	$(CXX) $(SIGCPP_CFLAGS) /Fo$@ /c ..\tests\testutilities.cc
+vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj: vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests ..\tests\testutilities.cc
+	$(CXX) $(SIGCPP_CFLAGS) /Fo$@ /Fd$(@D)\ /c ..\tests\testutilities.cc
 # Rules for building .lib files
 $(LIBSIGC_LIB): $(LIBSIGC_DLL)
 
-{.}.rc{$(CFG)\$(PLAT)\libsigcpp\}.res:
+{.}.rc{vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp\}.res:
 	rc /fo$@ $<
 
-{..\untracked\MSVC_NMake\}.rc{$(CFG)\$(PLAT)\libsigcpp\}.res:
+{..\untracked\MSVC_NMake\}.rc{vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp\}.res:
 	rc /fo$@ $<
 
 # Rules for linking DLLs
@@ -41,7 +41,7 @@ $(LIBSIGC_LIB): $(LIBSIGC_DLL)
 # $(dependent_objects)
 # <<
 # 	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;2
-$(LIBSIGC_DLL): $(CFG)\$(PLAT)\libsigcpp $(libsigcpp_dll_OBJS)
+$(LIBSIGC_DLL): vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp $(libsigcpp_dll_OBJS)
 	link /DLL $(LDFLAGS) /implib:$(LIBSIGC_LIB) -out:$@ @<<
 $(libsigcpp_dll_OBJS)
 <<
@@ -55,36 +55,38 @@ $(libsigcpp_dll_OBJS)
 # <<
 # 	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;1
 
-{..\examples\}.cc{$(CFG)\$(PLAT)\}.exe:
-	@if not exist $(CFG)\$(PLAT)\libsigcpp-ex $(MAKE) -f Makefile.vc CFG=$(CFG) $(CFG)\$(PLAT)\libsigcpp-ex
+{..\examples\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\}.exe:
+	@if not exist vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-ex $(MAKE) -f Makefile.vc CFG=$(CFG) vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-ex
 	@if not exist $(LIBSIGC_LIB) $(MAKE) -f Makefile.vc CFG=$(CFG) $(LIBSIGC_LIB)
-	$(CXX) $(SIGCPP_CFLAGS) /Fo$(CFG)\$(PLAT)\libsigcpp-ex\ $< /Fe$@ /link $(LDFLAGS) $(LIBSIGC_LIB)
+	$(CXX) $(SIGCPP_CFLAGS) /Fo$(@D)\libsigcpp-ex\ /Fd$(@D)\libsigcpp-ex\ $< /Fe$@ /link $(LDFLAGS) $(LIBSIGC_LIB)
 	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;1
 
-{..\tests\}.cc{$(CFG)\$(PLAT)\}.exe:
+{..\tests\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\}.exe:
 	@if not exist $(LIBSIGC_LIB) $(MAKE) -f Makefile.vc CFG=$(CFG) $(LIBSIGC_LIB)
-	@if not exist $(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj $(MAKE) -f Makefile.vc CFG=$(CFG) $(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj
-	$(CXX) $(SIGCPP_CFLAGS) /Fo$(CFG)\$(PLAT)\libsigcpp-tests\ $< /Fe$@ /link $(LDFLAGS) $(LIBSIGC_LIB) $(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj
+	@if not exist vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj $(MAKE) -f Makefile.vc CFG=$(CFG) vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj
+	$(CXX) $(SIGCPP_CFLAGS) /Fo$(@D)\libsigcpp-tests\ /Fd$(@D)\libsigcpp-tests\ $< /Fe$@ /link $(LDFLAGS) $(LIBSIGC_LIB) vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj
 	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;1
 
-$(CFG)\$(PLAT)\libsigc++-benchmark.exe: ..\tests\benchmark.cc
+vs$(VSVER)\$(CFG)\$(PLAT)\libsigc++-benchmark.exe: ..\tests\benchmark.cc
 	@if not exist $(LIBSIGC_LIB) $(MAKE) -f Makefile.vc CFG=$(CFG) $(LIBSIGC_LIB)
-	@if not exist $(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj $(MAKE) -f Makefile.vc CFG=$(CFG) $(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj
-	$(CXX) $(SIGCPP_BENCHMARK_CFLAGS) /Fo$(CFG)\$(PLAT)\libsigcpp-tests\ ..\tests\benchmark.cc /Fe$@ /link $(LDFLAGS) $(LIBSIGC_LIB) $(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj
+	@if not exist vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj $(MAKE) -f Makefile.vc CFG=$(CFG) vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj
+	$(CXX) $(SIGCPP_BENCHMARK_CFLAGS) /Fo$(@D)\libsigcpp-tests\ /Fd$(@D)\libsigcpp-tests\ ..\tests\benchmark.cc /Fe$@ /link $(LDFLAGS) $(LIBSIGC_LIB) vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj
 	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;1
 
 clean:
-	@-del /f /q $(CFG)\$(PLAT)\*.exe
-	@-del /f /q $(CFG)\$(PLAT)\*.dll
-	@-del /f /q $(CFG)\$(PLAT)\*.pdb
-	@-del /f /q $(CFG)\$(PLAT)\*.ilk
-	@-del /f /q $(CFG)\$(PLAT)\*.exp
-	@-del /f /q $(CFG)\$(PLAT)\*.lib
-	@-if exist $(CFG)\$(PLAT)\libsigcpp-tests del /f /q $(CFG)\$(PLAT)\libsigcpp-tests\*.obj
-	@-del /f /q $(CFG)\$(PLAT)\libsigcpp-ex\*.obj
-	@-del /f /q $(CFG)\$(PLAT)\libsigcpp\*.res
-	@-del /f /q $(CFG)\$(PLAT)\libsigcpp\*.obj
-	@-if exist $(CFG)\$(PLAT)\libsigcpp-tests rd $(CFG)\$(PLAT)\libsigcpp-tests
-	@-rd $(CFG)\$(PLAT)\libsigcpp-ex
-	@-rd $(CFG)\$(PLAT)\libsigcpp
-	@-del /f /q vc$(PDBVER)0.pdb
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.exe
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.dll
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.pdb
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.ilk
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.exp
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.lib
+	@-if exist vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests\*.obj
+	@-if exist vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests\*.pdb
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-ex\*.obj
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-ex\*.pdb
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp\*.res
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp\*.obj
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp\*.pdb
+	@-if exist vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests rd vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests
+	@-rd vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-ex
+	@-rd vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp

--- a/MSVC_NMake/config-msvc.mak
+++ b/MSVC_NMake/config-msvc.mak
@@ -29,11 +29,11 @@ LIBSIGCPP_CFLAGS = $(SIGCPP_CFLAGS) $(LIBSIGCPP_DEFINES)
 
 LIBSIGC_LIBNAME = sigc-vc$(VSVER)0$(LIBSIGC_DEBUG_SUFFIX)-$(LIBSIGC_MAJOR_VERSION)_$(LIBSIGC_MINOR_VERSION)
 
-LIBSIGC_DLL = $(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).dll
-LIBSIGC_LIB = $(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).lib
+LIBSIGC_DLL = vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).dll
+LIBSIGC_LIB = vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).lib
 
 # Note that building the benchmark requires Boost!
-libsigc_bench = $(CFG)\$(PLAT)\libsigc++-benchmark.exe
+libsigc_bench = vs$(VSVER)\$(CFG)\$(PLAT)\libsigc++-benchmark.exe
 
 # If your Boost libraries are built as DLLs, use BOOST_DLL=1 in your NMake command line
 !ifdef BOOST_DLL

--- a/MSVC_NMake/config-msvc.mak
+++ b/MSVC_NMake/config-msvc.mak
@@ -16,7 +16,7 @@ LIBSIGC_DEBUG_SUFFIX =
 
 LIBSIGCPP_DEFINES = /DSIGC_BUILD /D_WINDLL
 
-SIGCPP_BASE_CFLAGS = /I.. /I. /wd4530 /std:c++17 $(CFLAGS)
+SIGCPP_BASE_CFLAGS = /I.. /I. /I..\untracked\MSVC_NMake /wd4530 /std:c++17 /EHsc $(CFLAGS)
 
 LIBSIGC_INT_SOURCES = $(sigc_sources_cc:/=\)
 LIBSIGC_INT_HDRS = $(sigc_public_h:/=\)

--- a/MSVC_NMake/create-lists-msvc.mak
+++ b/MSVC_NMake/create-lists-msvc.mak
@@ -38,10 +38,10 @@ NULL=
 !if [call create-lists.bat header libsigcpp.mak libsigcpp_dll_OBJS]
 !endif
 
-!if [for %c in ($(sigc_sources_cc)) do @if "%~xc" == ".cc" @call create-lists.bat file libsigcpp.mak ^$(CFG)\^$(PLAT)\libsigcpp\%~nc.obj]
+!if [for %c in ($(sigc_sources_cc)) do @if "%~xc" == ".cc" @call create-lists.bat file libsigcpp.mak vs^$(VSVER)\^$(CFG)\^$(PLAT)\libsigcpp\%~nc.obj]
 !endif
 
-!if [@call create-lists.bat file libsigcpp.mak ^$(CFG)\^$(PLAT)\libsigcpp\sigc.res]
+!if [@call create-lists.bat file libsigcpp.mak vs^$(VSVER)\^$(CFG)\^$(PLAT)\libsigcpp\sigc.res]
 !endif
 
 !if [call create-lists.bat footer libsigcpp.mak]
@@ -50,7 +50,7 @@ NULL=
 !if [call create-lists.bat header libsigcpp.mak libsigc_ex]
 !endif
 
-!if [for %s in (..\examples\*.cc) do @call create-lists.bat file libsigcpp.mak ^$(CFG)\^$(PLAT)\%~ns.exe]
+!if [for %s in (..\examples\*.cc) do @call create-lists.bat file libsigcpp.mak vs^$(VSVER)\^$(CFG)\^$(PLAT)\%~ns.exe]
 !endif
 
 !if [call create-lists.bat footer libsigcpp.mak]
@@ -61,7 +61,7 @@ NULL=
 
 # Skipping testutilities.cc: Not to be built as a .exe, but is a common dependency for the tests
 #          benchmark: Not built on default; requires Boost
-!if [for %s in (..\tests\*.cc) do @if not "%~ns" == "testutilities" if not "%~ns" == "benchmark" @call create-lists.bat file libsigcpp.mak ^$(CFG)\^$(PLAT)\%~ns.exe]
+!if [for %s in (..\tests\*.cc) do @if not "%~ns" == "testutilities" if not "%~ns" == "benchmark" @call create-lists.bat file libsigcpp.mak vs^$(VSVER)\^$(CFG)\^$(PLAT)\%~ns.exe]
 !endif
 
 !if [call create-lists.bat footer libsigcpp.mak]

--- a/MSVC_NMake/detectenv-msvc.mak
+++ b/MSVC_NMake/detectenv-msvc.mak
@@ -121,6 +121,9 @@ CFLAGS_ADD = /MD /O2 /GL /MP
 !if "$(VSVER)" != "9"
 CFLAGS_ADD = $(CFLAGS_ADD) /d2Zi+
 !endif
+!if $(VSVER) >= 14
+CFLAGS_ADD = $(CFLAGS_ADD) /utf-8
+!endif
 !else
 CFLAGS_ADD = /MDd /Od
 !endif

--- a/MSVC_NMake/generate-msvc.mak
+++ b/MSVC_NMake/generate-msvc.mak
@@ -4,5 +4,7 @@
 # one is maintaining the NMake build files.
 
 # Create the build directories
-$(CFG)\$(PLAT)\libsigcpp $(CFG)\$(PLAT)\libsigcpp-ex $(CFG)\$(PLAT)\libsigcpp-tests:
+vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp	\
+vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-ex	\
+vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests:
 	@-mkdir $@

--- a/MSVC_NMake/install.mak
+++ b/MSVC_NMake/install.mak
@@ -7,9 +7,9 @@ install: all
 	@if not exist $(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\adaptors\ @mkdir $(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\adaptors
 	@if not exist $(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\functors\ @mkdir $(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\functors
 	@if not exist $(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\tuple-utils\ @mkdir $(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\tuple-utils
-	@copy /b $(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).dll $(PREFIX)\bin
-	@copy /b $(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).pdb $(PREFIX)\bin
-	@copy /b $(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).lib $(PREFIX)\lib
+	@copy /b vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).dll $(PREFIX)\bin
+	@copy /b vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).pdb $(PREFIX)\bin
+	@copy /b vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).lib $(PREFIX)\lib
 	@for %h in ($(LIBSIGC_INT_HDRS)) do @copy "..\sigc++\%h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\%h"
 	@if exist sigc++config.h copy "sigc++config.h" "$(PREFIX)\lib\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\include\"
 	@if exist ..\untracked\MSVC_NMake\sigc++config.h copy "..\untracked\MSVC_NMake\sigc++config.h" "$(PREFIX)\lib\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\include\"

--- a/MSVC_NMake/install.mak
+++ b/MSVC_NMake/install.mak
@@ -11,4 +11,5 @@ install: all
 	@copy /b $(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).pdb $(PREFIX)\bin
 	@copy /b $(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).lib $(PREFIX)\lib
 	@for %h in ($(LIBSIGC_INT_HDRS)) do @copy "..\sigc++\%h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\%h"
-	@copy "sigc++config.h" "$(PREFIX)\lib\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\include\"
+	@if exist sigc++config.h copy "sigc++config.h" "$(PREFIX)\lib\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\include\"
+	@if exist ..\untracked\MSVC_NMake\sigc++config.h copy "..\untracked\MSVC_NMake\sigc++config.h" "$(PREFIX)\lib\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\include\"

--- a/MSVC_NMake/meson.build
+++ b/MSVC_NMake/meson.build
@@ -13,5 +13,5 @@ configure_file(
 cmd_py = '''
 import shutil
 shutil.copy2("@0@", "@1@")
-'''.format(project_build_root / 'sigc++config.h', meson.current_build_dir())
+'''.format(project_build_root / 'sigc++config.h', project_build_root / 'MSVC_NMake')
 meson.add_postconf_script(python3.path(), '-c', cmd_py)

--- a/MSVC_NMake/meson.build
+++ b/MSVC_NMake/meson.build
@@ -3,7 +3,7 @@
 # Input: pkg_conf_data, project_build_root, python3
 # Output: -
 
-configure_file(
+sigc_rc = configure_file(
   input: 'sigc.rc.in',
   output: '@BASENAME@',
   configuration: pkg_conf_data,

--- a/MSVC_NMake/meson.build
+++ b/MSVC_NMake/meson.build
@@ -15,3 +15,19 @@ import shutil
 shutil.copy2("@0@", "@1@")
 '''.format(project_build_root / 'sigc++config.h', project_build_root / 'MSVC_NMake')
 meson.add_postconf_script(python3.path(), '-c', cmd_py)
+
+untracked_msvc_nmake = 'untracked' / 'MSVC_NMake'
+handle_built_files = project_source_root / 'tools' / 'handle-built-files.py'
+
+if not meson.is_subproject()
+  # Distribute built files.
+  # (add_dist_script() is not allowed in a subproject)
+
+  meson.add_dist_script(
+    python3.path(), dist_cmd,
+    python3.path(), handle_built_files, 'dist_gen_msvc_files',
+    meson.current_build_dir(),
+    untracked_msvc_nmake,
+    project_build_root / 'sigc++config.h', meson.current_build_dir() / 'sigc.rc',
+  )
+endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -56,6 +56,7 @@ EXTRA_DIST = \
   sigc++/meson.build \
   tests/meson.build \
   tools/dist-cmd.py \
+  tools/handle-built-files.py \
   tools/tutorial-custom-cmd.py \
   untracked/README
 

--- a/meson.build
+++ b/meson.build
@@ -39,7 +39,7 @@ project_build_root = meson.current_build_dir()
 
 cpp_compiler = meson.get_compiler('cpp')
 is_msvc = cpp_compiler.get_id() == 'msvc'
-python3 = import('python').find_installation('python3')
+python3 = import('python').find_installation()
 
 python_version = python3.language_version()
 python_version_req = '>= 3.5'

--- a/sigc++/meson.build
+++ b/sigc++/meson.build
@@ -69,15 +69,24 @@ install_headers(functors_h_files, subdir: sigcxx_pcname / 'sigc++' / 'functors')
 install_headers(tuple_utils_h_files, subdir: sigcxx_pcname / 'sigc++' / 'tuple-utils')
 
 extra_sigc_cppflags = []
+extra_sigc_objects = []
 
 # Make sure we are exporting the symbols from the DLL
 if is_msvc
   extra_sigc_cppflags += ['-DSIGC_BUILD', '-D_WINDLL']
 endif
 
+# Build the .rc file for Windows builds and link to it
+if host_machine.system() == 'windows'
+  windows = import('windows')
+  sigc_res = windows.compile_resources(sigc_rc)
+  extra_sigc_objects += sigc_res
+endif
+
 extra_include_dirs = ['..']
 sigcxx_library = library(sigcxx_pcname,
   source_cc_files,
+  extra_sigc_objects,
   version: sigcxx_libversion,
   include_directories: extra_include_dirs,
   cpp_args: extra_sigc_cppflags,

--- a/tools/handle-built-files.py
+++ b/tools/handle-built-files.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+# External command, intended to be called with run_command(), custom_target(),
+# meson.add_install_script() and meson.add_dist_script().
+
+#                         argv[1]   argv[2:]
+# handle-built-files.py <subcommand> <xxx>...
+
+import os
+import sys
+import shutil
+import subprocess
+from pathlib import Path
+
+subcommand = sys.argv[1]
+
+# Invoked from meson.add_dist_script().
+def dist_built_files(is_msvc_files=False):
+  #     argv[2]        argv[3]     argv[4:]
+  # <built_h_cc_dir> <dist_dir> <built_files>...
+
+  # <built_h_cc_dir> is an absolute path in the build directory or source directory.
+  # <dist_dir> is a distribution directory, relative to MESON_DIST_ROOT.
+  built_h_cc_dir = sys.argv[2]
+  dist_dir_root = os.path.join(os.getenv('MESON_DIST_ROOT'), sys.argv[3])
+  dist_dir = dist_dir_root
+
+  # Distribute .h and .cc files built from .m4 files, or generated MSVC files.
+  for file in sys.argv[4:]:
+    if not is_msvc_files:
+      dist_dir = os.path.join(dist_dir_root, os.path.dirname(file))
+
+    # Create the distribution directory, if it does not exist.
+    os.makedirs(dist_dir, exist_ok=True)
+
+    shutil.copy(os.path.join(built_h_cc_dir, file), dist_dir)
+  return 0
+
+# ----- Main -----
+if subcommand == 'dist_gen_msvc_files':
+  sys.exit(dist_built_files(True))
+print(sys.argv[0], ': illegal subcommand,', subcommand)
+sys.exit(1)


### PR DESCRIPTION
Hi,

I went a bit further to see whether we can build libsigc++ master in maintainer mode even on Visual Studio builds, and it turns out that it is indeed possible, but it does take some extra steps which involved installing <code>mm-common</code>, <code>doxygen</code>, and <code>GraphViz</code> (<code>GraphViz</code> involves installing a pretty recent mingw-w64).

It seems though, with the above items installed, we still need one small change to <code>meson.build</code> so that things will work, up to and including 'meson dist'.

From the commit message:

<i>Since we are assured that we are using Python 3.x on when we run Meson, we do not really need to look for the 'python3' executable, but we could just use whatever Python interpreter that is used to run Meson.</i>

<i>This will fix situations where it is commonly the case where we may have multiple Python 3.x installations on Windows (www.python.org, and those from Cygwin/mingw-w64), so that Meson really uses one and only one Python installation to run everything that is Python-related, which will
thus fix '[meson|ninja] dist' on Visual Studio builds.</i>

I also managed to re-produce the error that was mentioned in [1], in MSVC_NMake/.  Apparently, this is only caused when the build directory is a subdirectory of the source tree, so this attempts to fix this, where it looks like Meson is not handling the path separators properly or so.

Another fix added is to build the .rc files on Windows so that we have the version info embedded in the libsigc++ DLL as we did in the NMake Makefiles (and the previous project files).

With blessings, thank you!

[1]: https://github.com/libsigcplusplus/libsigcplusplus/pull/49#issuecomment-567475690