### PR TITLE
More fixes for Meson builds with Visual Studio (libsigc++-2-10)

### DIFF
--- a/MSVC_NMake/build-rules-msvc.mak
+++ b/MSVC_NMake/build-rules-msvc.mak
@@ -28,12 +28,20 @@ $<
 $<
 <<
 
+{..\untracked\sigc++\adaptors\lambda\}.cc{$(CFG)\$(PLAT)\libsigcpp\}.obj::
+	$(CXX) $(LIBSIGCPP_CFLAGS) /Fo$(CFG)\$(PLAT)\libsigcpp\ /c @<<
+$<
+<<
+
 $(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj: $(CFG)\$(PLAT)\libsigcpp-tests ..\tests\testutilities.cc
 	$(CXX) $(SIGCPP_CFLAGS) /Fo$@ /c ..\tests\testutilities.cc
 # Rules for building .lib files
 $(LIBSIGC_LIB): $(LIBSIGC_DLL)
 
 {.}.rc{$(CFG)\$(PLAT)\libsigcpp\}.res:
+	rc /fo$@ $<
+
+{..\untracked\MSVC_NMake\}.rc{$(CFG)\$(PLAT)\libsigcpp\}.res:
 	rc /fo$@ $<
 
 # Rules for linking DLLs

--- a/MSVC_NMake/build-rules-msvc.mak
+++ b/MSVC_NMake/build-rules-msvc.mak
@@ -13,35 +13,35 @@
 # 	$(CC)|$(CXX) $(cflags) /Fo$(destdir) /c @<<
 # $<
 # <<
-{..\sigc++\}.cc{$(CFG)\$(PLAT)\libsigcpp\}.obj::
-	$(CXX) $(LIBSIGCPP_CFLAGS) /Fo$(CFG)\$(PLAT)\libsigcpp\ /c @<<
+{..\sigc++\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp\}.obj:
+	$(CXX) $(LIBSIGCPP_CFLAGS) /Fo$(@D)\ /Fd$(@D)\ /c @<<
 $<
 <<
 
-{..\sigc++\adaptors\lambda\}.cc{$(CFG)\$(PLAT)\libsigcpp\}.obj::
-	$(CXX) $(LIBSIGCPP_CFLAGS) /Fo$(CFG)\$(PLAT)\libsigcpp\ /c @<<
+{..\sigc++\adaptors\lambda\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp\}.obj:
+	$(CXX) $(LIBSIGCPP_CFLAGS) /Fo$(@D)\ /Fd$(@D)\ /c @<<
 $<
 <<
 
-{..\sigc++\functors\}.cc{$(CFG)\$(PLAT)\libsigcpp\}.obj::
-	$(CXX) $(LIBSIGCPP_CFLAGS) /Fo$(CFG)\$(PLAT)\libsigcpp\ /c @<<
+{..\sigc++\functors\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp\}.obj:
+	$(CXX) $(LIBSIGCPP_CFLAGS) /Fo$(@D)\ /Fd$(@D)\ /c @<<
 $<
 <<
 
-{..\untracked\sigc++\adaptors\lambda\}.cc{$(CFG)\$(PLAT)\libsigcpp\}.obj::
-	$(CXX) $(LIBSIGCPP_CFLAGS) /Fo$(CFG)\$(PLAT)\libsigcpp\ /c @<<
+{..\untracked\sigc++\adaptors\lambda\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp\}.obj:
+	$(CXX) $(LIBSIGCPP_CFLAGS) /Fo$(@D)\ /Fd$(@D)\ /c @<<
 $<
 <<
 
-$(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj: $(CFG)\$(PLAT)\libsigcpp-tests ..\tests\testutilities.cc
-	$(CXX) $(SIGCPP_CFLAGS) /Fo$@ /c ..\tests\testutilities.cc
+vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj: vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests ..\tests\testutilities.cc
+	$(CXX) $(SIGCPP_CFLAGS) /Fo$@ /Fd$(@D)\ /c ..\tests\testutilities.cc
 # Rules for building .lib files
 $(LIBSIGC_LIB): $(LIBSIGC_DLL)
 
-{.}.rc{$(CFG)\$(PLAT)\libsigcpp\}.res:
+{.}.rc{vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp\}.res:
 	rc /fo$@ $<
 
-{..\untracked\MSVC_NMake\}.rc{$(CFG)\$(PLAT)\libsigcpp\}.res:
+{..\untracked\MSVC_NMake\}.rc{vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp\}.res:
 	rc /fo$@ $<
 
 # Rules for linking DLLs
@@ -51,7 +51,7 @@ $(LIBSIGC_LIB): $(LIBSIGC_DLL)
 # $(dependent_objects)
 # <<
 # 	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;2
-$(LIBSIGC_DLL): $(CFG)\$(PLAT)\libsigcpp $(libsigcpp_dll_OBJS)
+$(LIBSIGC_DLL): vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp $(libsigcpp_dll_OBJS)
 	link /DLL $(LDFLAGS) /implib:$(LIBSIGC_LIB) -out:$@ @<<
 $(libsigcpp_dll_OBJS)
 <<
@@ -65,36 +65,38 @@ $(libsigcpp_dll_OBJS)
 # <<
 # 	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;1
 
-{..\examples\}.cc{$(CFG)\$(PLAT)\}.exe:
-	@if not exist $(CFG)\$(PLAT)\libsigcpp-ex $(MAKE) -f Makefile.vc CFG=$(CFG) $(CFG)\$(PLAT)\libsigcpp-ex
+{..\examples\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\}.exe:
+	@if not exist vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-ex $(MAKE) -f Makefile.vc CFG=$(CFG) vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-ex
 	@if not exist $(LIBSIGC_LIB) $(MAKE) -f Makefile.vc CFG=$(CFG) $(LIBSIGC_LIB)
-	$(CXX) $(SIGCPP_CFLAGS) /Fo$(CFG)\$(PLAT)\libsigcpp-ex\ $< /Fe$@ /link $(LDFLAGS) $(LIBSIGC_LIB)
+	$(CXX) $(SIGCPP_CFLAGS) /Fo$(@D)\libsigcpp-ex\ /Fd$(@D)\libsigcpp-ex\ $< /Fe$@ /link $(LDFLAGS) $(LIBSIGC_LIB)
 	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;1
 
-{..\tests\}.cc{$(CFG)\$(PLAT)\}.exe:
+{..\tests\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\}.exe:
 	@if not exist $(LIBSIGC_LIB) $(MAKE) -f Makefile.vc CFG=$(CFG) $(LIBSIGC_LIB)
-	@if not exist $(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj $(MAKE) -f Makefile.vc CFG=$(CFG) $(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj
-	$(CXX) $(SIGCPP_CFLAGS) /Fo$(CFG)\$(PLAT)\libsigcpp-tests\ $< /Fe$@ /link $(LDFLAGS) $(LIBSIGC_LIB) $(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj
+	@if not exist vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj $(MAKE) -f Makefile.vc CFG=$(CFG) vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj
+	$(CXX) $(SIGCPP_CFLAGS) /Fo$(@D)\libsigcpp-tests\ /Fd$(@D)\libsigcpp-tests\ $< /Fe$@ /link $(LDFLAGS) $(LIBSIGC_LIB) vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj
 	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;1
 
-$(CFG)\$(PLAT)\libsigc++-benchmark.exe: ..\tests\benchmark.cc
+vs$(VSVER)\$(CFG)\$(PLAT)\libsigc++-benchmark.exe: ..\tests\benchmark.cc
 	@if not exist $(LIBSIGC_LIB) $(MAKE) -f Makefile.vc CFG=$(CFG) $(LIBSIGC_LIB)
-	@if not exist $(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj $(MAKE) -f Makefile.vc CFG=$(CFG) $(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj
-	$(CXX) $(SIGCPP_BENCHMARK_CFLAGS) /Fo$(CFG)\$(PLAT)\libsigcpp-tests\ ..\tests\benchmark.cc /Fe$@ /link $(LDFLAGS) $(LIBSIGC_LIB) $(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj
+	@if not exist vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj $(MAKE) -f Makefile.vc CFG=$(CFG) vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj
+	$(CXX) $(SIGCPP_BENCHMARK_CFLAGS) /Fo$(@D)\libsigcpp-tests\ /Fd$(@D)\libsigcpp-tests\ ..\tests\benchmark.cc /Fe$@ /link $(LDFLAGS) $(LIBSIGC_LIB) vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests\testutilities.obj
 	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;1
 
 clean:
-	@-del /f /q $(CFG)\$(PLAT)\*.exe
-	@-del /f /q $(CFG)\$(PLAT)\*.dll
-	@-del /f /q $(CFG)\$(PLAT)\*.pdb
-	@-del /f /q $(CFG)\$(PLAT)\*.ilk
-	@-del /f /q $(CFG)\$(PLAT)\*.exp
-	@-del /f /q $(CFG)\$(PLAT)\*.lib
-	@-if exist $(CFG)\$(PLAT)\libsigcpp-tests del /f /q $(CFG)\$(PLAT)\libsigcpp-tests\*.obj
-	@-del /f /q $(CFG)\$(PLAT)\libsigcpp-ex\*.obj
-	@-del /f /q $(CFG)\$(PLAT)\libsigcpp\*.res
-	@-del /f /q $(CFG)\$(PLAT)\libsigcpp\*.obj
-	@-if exist $(CFG)\$(PLAT)\libsigcpp-tests rd $(CFG)\$(PLAT)\libsigcpp-tests
-	@-rd $(CFG)\$(PLAT)\libsigcpp-ex
-	@-rd $(CFG)\$(PLAT)\libsigcpp
-	@-del /f /q vc$(PDBVER)0.pdb
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.exe
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.dll
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.pdb
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.ilk
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.exp
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.lib
+	@-if exist vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests\*.obj
+	@-if exist vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests\*.pdb
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-ex\*.obj
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-ex\*.pdb
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp\*.res
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp\*.obj
+	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp\*.pdb
+	@-if exist vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests rd vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests
+	@-rd vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-ex
+	@-rd vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp

--- a/MSVC_NMake/config-msvc.mak
+++ b/MSVC_NMake/config-msvc.mak
@@ -1,6 +1,6 @@
 # NMake Makefile portion for enabling features for Windows builds
 
-# These are the base minimum libraries required for building gjs.
+# These are the base minimum libraries required for building libsigc++.
 BASE_INCLUDES =	/I$(PREFIX)\include
 
 # Please do not change anything beneath this line unless maintaining the NMake Makefiles
@@ -16,7 +16,7 @@ LIBSIGC_DEBUG_SUFFIX =
 
 LIBSIGCPP_DEFINES = /DSIGC_BUILD /D_WINDLL
 
-SIGCPP_BASE_CFLAGS = /I.. /I. /wd4530 $(CFLAGS)
+SIGCPP_BASE_CFLAGS = /I.. /I. /I..\untracked /I..\MSVC_NMake /wd4530 /EHsc $(CFLAGS)
 
 LIBSIGC_INT_SOURCES = $(sigc_sources_cc:/=\)
 LIBSIGC_INT_HDRS = $(sigc_public_h:/=\)

--- a/MSVC_NMake/config-msvc.mak
+++ b/MSVC_NMake/config-msvc.mak
@@ -29,11 +29,11 @@ LIBSIGCPP_CFLAGS = $(SIGCPP_CFLAGS) $(LIBSIGCPP_DEFINES)
 
 LIBSIGC_LIBNAME = sigc-vc$(PDBVER)0$(LIBSIGC_DEBUG_SUFFIX)-$(LIBSIGC_MAJOR_VERSION)_$(LIBSIGC_MINOR_VERSION)
 
-LIBSIGC_DLL = $(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).dll
-LIBSIGC_LIB = $(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).lib
+LIBSIGC_DLL = vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).dll
+LIBSIGC_LIB = vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).lib
 
 # Note that building the benchmark requires Boost!
-libsigc_bench = $(CFG)\$(PLAT)\libsigc++-benchmark.exe
+libsigc_bench = vs$(VSVER)\$(CFG)\$(PLAT)\libsigc++-benchmark.exe
 
 # If your Boost libraries are built as DLLs, use BOOST_DLL=1 in your NMake command line
 !ifdef BOOST_DLL

--- a/MSVC_NMake/create-lists-msvc.mak
+++ b/MSVC_NMake/create-lists-msvc.mak
@@ -38,10 +38,10 @@ NULL=
 !if [call create-lists.bat header libsigcpp.mak libsigcpp_dll_OBJS]
 !endif
 
-!if [for %c in ($(sigc_sources_cc)) do @if "%~xc" == ".cc" @call create-lists.bat file libsigcpp.mak ^$(CFG)\^$(PLAT)\libsigcpp\%~nc.obj]
+!if [for %c in ($(sigc_sources_cc)) do @if "%~xc" == ".cc" @call create-lists.bat file libsigcpp.mak vs^$(VSVER)\^$(CFG)\^$(PLAT)\libsigcpp\%~nc.obj]
 !endif
 
-!if [@call create-lists.bat file libsigcpp.mak ^$(CFG)\^$(PLAT)\libsigcpp\sigc.res]
+!if [@call create-lists.bat file libsigcpp.mak vs^$(VSVER)\^$(CFG)\^$(PLAT)\libsigcpp\sigc.res]
 !endif
 
 !if [call create-lists.bat footer libsigcpp.mak]
@@ -50,7 +50,7 @@ NULL=
 !if [call create-lists.bat header libsigcpp.mak libsigc_ex]
 !endif
 
-!if [for %s in (..\examples\*.cc) do @call create-lists.bat file libsigcpp.mak ^$(CFG)\^$(PLAT)\%~ns.exe]
+!if [for %s in (..\examples\*.cc) do @call create-lists.bat file libsigcpp.mak vs^$(VSVER)\^$(CFG)\^$(PLAT)\%~ns.exe]
 !endif
 
 !if [call create-lists.bat footer libsigcpp.mak]
@@ -61,7 +61,7 @@ NULL=
 
 # Skipping testutilities.cc: Not to be built as a .exe, but is a common dependency for the tests
 #          benchmark: Not built on default; requires Boost
-!if [for %s in (..\tests\*.cc) do @if not "%~ns" == "testutilities" if not "%~ns" == "benchmark" @call create-lists.bat file libsigcpp.mak ^$(CFG)\^$(PLAT)\%~ns.exe]
+!if [for %s in (..\tests\*.cc) do @if not "%~ns" == "testutilities" if not "%~ns" == "benchmark" @call create-lists.bat file libsigcpp.mak vs^$(VSVER)\^$(CFG)\^$(PLAT)\%~ns.exe]
 !endif
 
 !if [call create-lists.bat footer libsigcpp.mak]

--- a/MSVC_NMake/generate-msvc.mak
+++ b/MSVC_NMake/generate-msvc.mak
@@ -4,5 +4,7 @@
 # one is maintaining the NMake build files.
 
 # Create the build directories
-$(CFG)\$(PLAT)\libsigcpp $(CFG)\$(PLAT)\libsigcpp-ex $(CFG)\$(PLAT)\libsigcpp-tests:
+vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp	\
+vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-ex	\
+vs$(VSVER)\$(CFG)\$(PLAT)\libsigcpp-tests:
 	@-mkdir $@

--- a/MSVC_NMake/install.mak
+++ b/MSVC_NMake/install.mak
@@ -12,8 +12,9 @@ install: all
 	@copy /b $(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).lib $(PREFIX)\lib
 	@copy "..\sigc++\sigc++.h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\"
 	@for %h in ($(LIBSIGC_INT_HDRS)) do @copy "..\sigc++\%h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\%h"
-	@for %h in ($(base_built_h)) do @copy "..\sigc++\%h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\%h"
-	@for %h in ($(functors_built_h)) do @copy "..\sigc++\functors\%h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\functors\%h"
-	@for %h in ($(adaptors_built_h)) do @copy "..\sigc++\adaptors\%h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\adaptors\%h"
-	@for %h in ($(lambda_built_h)) do @copy "..\sigc++\adaptors\lambda\%h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\adaptors\lambda\%h"
-	@copy "sigc++config.h" "$(PREFIX)\lib\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\include\"
+	@for %d in (sigc++ untracked\sigc++) do @(for %h in ($(base_built_h)) do @if exist ..\%d\%h copy "..\%d\%h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\%h")
+	@for %d in (sigc++ untracked\sigc++) do @(for %h in ($(functors_built_h)) do @if exist ..\%d\functors\%h copy "..\%d\functors\%h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\functors\%h")
+	@for %d in (sigc++ untracked\sigc++) do @(for %h in ($(adaptors_built_h)) do @if exist ..\%d\adaptors\%h copy "..\%d\adaptors\%h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\adaptors\%h")
+	@for %d in (sigc++ untracked\sigc++) do @(for %h in ($(lambda_built_h)) do @if exist ..\%d\adaptors\lambda\%h copy "..\%d\adaptors\lambda\%h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\adaptors\lambda\%h")
+	@if exist sigc++config.h copy "sigc++config.h" "$(PREFIX)\lib\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\include\"
+	@if exist ..\untracked\MSVC_NMake\sigc++config.h copy "..\untracked\MSVC_NMake\sigc++config.h" "$(PREFIX)\lib\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\include\"

--- a/MSVC_NMake/install.mak
+++ b/MSVC_NMake/install.mak
@@ -7,9 +7,9 @@ install: all
 	@if not exist $(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\adaptors\lambda\ @mkdir $(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\adaptors\lambda
 	@if not exist $(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\functors\ @mkdir $(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\functors
 	@if not exist $(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\tuple-utils\ @mkdir $(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\tuple-utils
-	@copy /b $(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).dll $(PREFIX)\bin
-	@copy /b $(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).pdb $(PREFIX)\bin
-	@copy /b $(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).lib $(PREFIX)\lib
+	@copy /b vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).dll $(PREFIX)\bin
+	@copy /b vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).pdb $(PREFIX)\bin
+	@copy /b vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).lib $(PREFIX)\lib
 	@copy "..\sigc++\sigc++.h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\"
 	@for %h in ($(LIBSIGC_INT_HDRS)) do @copy "..\sigc++\%h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\%h"
 	@for %d in (sigc++ untracked\sigc++) do @(for %h in ($(base_built_h)) do @if exist ..\%d\%h copy "..\%d\%h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\%h")

--- a/MSVC_NMake/meson.build
+++ b/MSVC_NMake/meson.build
@@ -13,5 +13,5 @@ configure_file(
 cmd_py = '''
 import shutil
 shutil.copy2("@0@", "@1@")
-'''.format(project_build_root / 'sigc++config.h', meson.current_build_dir())
+'''.format(project_build_root / 'sigc++config.h', project_build_root / 'MSVC_NMake')
 meson.add_postconf_script(python3.path(), '-c', cmd_py)

--- a/MSVC_NMake/meson.build
+++ b/MSVC_NMake/meson.build
@@ -3,7 +3,7 @@
 # Input: pkg_conf_data, project_build_root, python3
 # Output: -
 
-configure_file(
+sigc_rc = configure_file(
   input: 'sigc.rc.in',
   output: '@BASENAME@',
   configuration: pkg_conf_data,

--- a/MSVC_NMake/meson.build
+++ b/MSVC_NMake/meson.build
@@ -9,9 +9,27 @@ sigc_rc = configure_file(
   configuration: pkg_conf_data,
 )
 
+generated_sigc_config_h_orig = project_build_root / 'sigc++config.h'
+
 # Copy the generated configuration header into the MSVC project directory.
 cmd_py = '''
 import shutil
 shutil.copy2("@0@", "@1@")
-'''.format(project_build_root / 'sigc++config.h', project_build_root / 'MSVC_NMake')
+'''.format(generated_sigc_config_h_orig, project_build_root / 'MSVC_NMake')
 meson.add_postconf_script(python3.path(), '-c', cmd_py)
+
+untracked_msvc_nmake = 'untracked' / 'MSVC_NMake'
+handle_built_files = project_source_root / 'tools' / 'handle-built-files.py'
+
+if not meson.is_subproject()
+  # Distribute built files.
+  # (add_dist_script() is not allowed in a subproject)
+
+  meson.add_dist_script(
+    python3.path(), dist_cmd,
+    python3.path(), handle_built_files, 'dist_gen_msvc_files',
+    meson.current_build_dir(),
+    untracked_msvc_nmake,
+    generated_sigc_config_h_orig, meson.current_build_dir() / 'sigc.rc',
+  )
+endif

--- a/meson.build
+++ b/meson.build
@@ -39,7 +39,7 @@ project_build_root = meson.current_build_dir()
 
 cpp_compiler = meson.get_compiler('cpp')
 is_msvc = cpp_compiler.get_id() == 'msvc'
-python3 = import('python').find_installation('python3')
+python3 = import('python').find_installation()
 
 python_version = python3.language_version()
 python_version_req = '>= 3.5'

--- a/meson.build
+++ b/meson.build
@@ -59,10 +59,6 @@ is_git_build = run_command(python3, '-c', cmd_py).returncode() == 0
 # is_git_build = run_command('test', '-d', project_source_root / '.git').returncode() == 0
 # Python code can be used in all operating sytems where Meson can run.
 
-# Unfortunately due to m4 requirements, we cannot support MSVC builds
-# directly from GIT checkouts
-assert(not is_msvc or not is_git_build, 'Direct builds from GIT is not supported for MSVC builds')
-
 # Options.
 maintainer_mode_opt = get_option('maintainer-mode')
 maintainer_mode = maintainer_mode_opt == 'true' or \

--- a/sigc++/meson.build
+++ b/sigc++/meson.build
@@ -93,10 +93,18 @@ src_untracked_sigcxx = project_source_root / untracked_sigcxx
 handle_built_files = project_source_root / 'tools' / 'handle-built-files.py'
 
 extra_sigc_cppflags = []
+extra_sigc_objects = []
 
 # Make sure we are exporting the symbols from the DLL
 if is_msvc
   extra_sigc_cppflags += ['-DSIGC_BUILD', '-D_WINDLL']
+endif
+
+# Build the .rc file for Windows builds and link to it
+if host_machine.system() == 'windows'
+  windows = import('windows')
+  sigc_res = windows.compile_resources(sigc_rc)
+  extra_sigc_objects += sigc_res
 endif
 
 if maintainer_mode
@@ -158,6 +166,7 @@ if maintainer_mode
   extra_include_dirs = ['..']
   sigcxx_library = library(sigcxx_pcname,
     source_cc_files, built_cc_file_targets, built_h_file_targets,
+    extra_sigc_objects,
     version: sigcxx_libversion,
     cpp_args: extra_sigc_cppflags,
     include_directories: extra_include_dirs,
@@ -200,6 +209,7 @@ else # not maintainer_mode
   extra_include_dirs = [ '..', '..' / 'untracked' ]
   sigcxx_library = library(sigcxx_pcname,
     source_cc_files, untracked_built_cc_files,
+    extra_sigc_objects,
     version: sigcxx_libversion,
     cpp_args: extra_sigc_cppflags,
     include_directories: extra_include_dirs,

--- a/sigc++/meson.build
+++ b/sigc++/meson.build
@@ -90,8 +90,6 @@ install_headers(functors_h_files, subdir: sigcxx_pcname / 'sigc++' / 'functors')
 untracked_sigcxx = 'untracked' / 'sigc++'
 src_untracked_sigcxx = project_source_root / untracked_sigcxx
 
-handle_built_files = project_source_root / 'tools' / 'handle-built-files.py'
-
 extra_sigc_cppflags = []
 extra_sigc_objects = []
 

--- a/tools/handle-built-files.py
+++ b/tools/handle-built-files.py
@@ -73,7 +73,7 @@ def install_built_h_files():
   return 0
 
 # Invoked from meson.add_dist_script().
-def dist_built_files():
+def dist_built_files(is_msvc_files=False):
   #     argv[2]        argv[3]     argv[4:]
   # <built_h_cc_dir> <dist_dir> <built_files>...
 
@@ -81,10 +81,12 @@ def dist_built_files():
   # <dist_dir> is a distribution directory, relative to MESON_DIST_ROOT.
   built_h_cc_dir = sys.argv[2]
   dist_dir_root = os.path.join(os.getenv('MESON_DIST_ROOT'), sys.argv[3])
+  dist_dir = dist_dir_root
 
-  # Distribute .h and .cc files built from .m4 files.
+  # Distribute .h and .cc files built from .m4 files, or generated MSVC files.
   for file in sys.argv[4:]:
-    dist_dir = os.path.join(dist_dir_root, os.path.dirname(file))
+    if not is_msvc_files:
+      dist_dir = os.path.join(dist_dir_root, os.path.dirname(file))
 
     # Create the distribution directory, if it does not exist.
     os.makedirs(dist_dir, exist_ok=True)
@@ -129,5 +131,7 @@ if subcommand == 'dist_built_files':
   sys.exit(dist_built_files())
 if subcommand == 'copy_built_files':
   sys.exit(copy_built_files())
+if subcommand == 'dist_gen_msvc_files':
+  sys.exit(dist_built_files(True))
 print(sys.argv[0], ': illegal subcommand,', subcommand)
 sys.exit(1)


### PR DESCRIPTION
Hi,

I went a bit further to refine things for the Meson builds on Visual Studio, namely:

*  Allow maintainer-mode/direct builds from GIT checkout on Visual Studio, too.  This is because one can install <code>m4</code> with mingw-w64 (and possibly Cygwin), which is sufficient for our needs here.
*  And all the changes in PR 51.

With blessings, thank you!