### PR TITLE
GitHub Actions CI: Add a clang++ 10 build

### DIFF
--- a/.github/workflows/autotools-clang-10.yml
+++ b/.github/workflows/autotools-clang-10.yml
@@ -1,0 +1,28 @@
+name: "CI: autotools: clang 10"
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build
+      run: |
+        # Prevent blocking the install on a question during configuring of tzdata.
+        export ENV DEBIAN_FRONTEND=noninteractive
+        apt update
+        apt install build-essential mm-common clang-10 --yes
+        export CXX=clang++-10
+        ./autogen.sh --enable-warnings=fatal
+        make
+    - name: Test
+      run: make check
+    - name: Distcheck
+      run: |
+        # distcheck runs configure again so we need to specify CXX again.
+        export CXX=clang++-10
+        make distcheck


### PR DESCRIPTION
Like the clang-10 CI, this uses a newer Ubuntu version (20.04) by
specifying a different docker image.  Because of that, we no longer need
to use sudo with apt.