### PR TITLE
Meson build: fix versioning on macOS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -31,6 +31,7 @@ sigcxx_libversion = '@0@.@1@.@2@'.format(
   libtool_soversion[0] - libtool_soversion[2],
   libtool_soversion[2],
   libtool_soversion[1])
+darwin_versions = [libtool_soversion[0] + 1, '@0@.@1@'.format(libtool_soversion[0] + 1, libtool_soversion[1])]
 
 # Use these instead of meson.source_root() and meson.build_root() in subdirectories.
 # source_root() and build_root() are not useful, if this is a subproject.

--- a/sigc++/meson.build
+++ b/sigc++/meson.build
@@ -169,6 +169,7 @@ if maintainer_mode
     cpp_args: extra_sigc_cppflags,
     include_directories: extra_include_dirs,
     dependencies: sigcxx_build_dep,
+    darwin_versions: darwin_versions,
     install: true,
   )
 
@@ -212,6 +213,7 @@ else # not maintainer_mode
     cpp_args: extra_sigc_cppflags,
     include_directories: extra_include_dirs,
     dependencies: sigcxx_build_dep,
+    darwin_versions: darwin_versions,
     install: true,
   )
 


### PR DESCRIPTION
This is necessary to ensure backwards compatibility with the libtool versioning scheme on macOS.

This PR is against the 2.10 branch. If this one is accepted, I will gladly open a similar one against master as well.