### PR TITLE
GitHub actions: Use ubuntu-20.04 directly

### DIFF
--- a/.github/workflows/autotools-clang-8.yml
+++ b/.github/workflows/autotools-clang-8.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/autotools-clang-9.yml
+++ b/.github/workflows/autotools-clang-9.yml
@@ -5,8 +5,7 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
-    container: ubuntu:20.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1
@@ -14,8 +13,8 @@ jobs:
       run: |
         # Prevent blocking apt install on a question during configuring of tzdata.
         export ENV DEBIAN_FRONTEND=noninteractive
-        apt update
-        apt install mm-common clang-9 make --yes
+        sudo apt update
+        sudo apt install mm-common clang-9 make --yes
         export CC=clang-9 CXX=clang++-9
         ./autogen.sh --enable-warnings=fatal
         make

--- a/.github/workflows/meson-clang-10.yml
+++ b/.github/workflows/meson-clang-10.yml
@@ -5,8 +5,7 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
-    container: ubuntu:20.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1
@@ -14,8 +13,8 @@ jobs:
       run: |
         # Prevent blocking apt install on a question during configuring of tzdata.
         export ENV DEBIAN_FRONTEND=noninteractive
-        apt update
-        apt install mm-common clang-10 meson ninja-build python3-setuptools --yes
+        sudo apt update
+        sudo apt install mm-common clang-10 meson ninja-build python3-setuptools --yes
         export CXX=clang++-10
         meson -Dwarnings=fatal _build
         cd _build
@@ -28,7 +27,7 @@ jobs:
         meson test
     - name: Dist
       run: |
-        apt install git --yes
+        sudo apt install git --yes
         # dist runs setup again so we need to specify CXX again.
         export CXX=clang++-10
         cd _build

--- a/.github/workflows/meson-gcc-9.yml
+++ b/.github/workflows/meson-gcc-9.yml
@@ -5,8 +5,7 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
-    container: ubuntu:20.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1
@@ -14,8 +13,8 @@ jobs:
       run: |
         # Prevent blocking apt install on a question during configuring of tzdata.
         export ENV DEBIAN_FRONTEND=noninteractive
-        apt update
-        apt install mm-common g++-9 meson ninja-build python3-setuptools --yes
+        sudo apt update
+        sudo apt install mm-common g++-9 meson ninja-build python3-setuptools --yes
         export CXX=g++-9
         meson -Dwarnings=fatal _build
         cd _build
@@ -28,7 +27,7 @@ jobs:
         meson test
     - name: Dist
       run: |
-        apt install git --yes
+        sudo apt install git --yes
         # dist runs setup again so we need to specify CXX again.
         export CXX=g++-9
         cd _build


### PR DESCRIPTION
GitHub Actions now supports ubuntu-20.04 directly, not only via a
separate container:
https://github.com/actions/virtual-environments

And use ubuntu-18.04 instead of ubuntu-latest, because that's what it
currently is, but ubuntu-latest will change to mean ubuntu-20.04 soon:
https://github.com/actions/virtual-environments/issues/1816