### PR TITLE
Fix build as subproject without building documentation

### DIFF
--- a/docs/docs/reference/meson.build
+++ b/docs/docs/reference/meson.build
@@ -4,7 +4,8 @@
 #        sigcxx_api_version, build_documentation, source_h_files,
 #        hg_ccg_basenames, install_datadir, python3, doc_reference,
 #        can_add_dist_script
-# Output: install_docdir, install_devhelpdir, book_name, tag_file
+# Output: install_docdir, install_devhelpdir, book_name,
+#         if build_documentation: tag_file
 
 # There are no built source files in libsigc++-3.0.
 
@@ -17,28 +18,30 @@ foreach module : tag_file_modules
   depmod = dependency(module, required: false)
   if depmod.found()
     if meson.version().version_compare('>=0.54.0')
-      doxytagfile = depmod.get_variable(pkgconfig: 'doxytagfile', internal: 'doxytagfile')
+      doxytagfile = depmod.get_variable(pkgconfig: 'doxytagfile', internal: 'doxytagfile', default_value: '')
       htmlrefpub = depmod.get_variable(pkgconfig: 'htmlrefpub', internal: 'htmlrefpub', default_value: '')
       htmlrefdir = depmod.get_variable(pkgconfig: 'htmlrefdir', internal: 'htmlrefdir', default_value: '')
     else
       # TODO: Remove the possibility to build with meson.version() < 0.54.0
       # when >= 0.54.0 is available in GitHub's CI (continuous integration).
-      doxytagfile = depmod.get_variable(pkgconfig: 'doxytagfile')
+      doxytagfile = depmod.get_variable(pkgconfig: 'doxytagfile', default_value: '')
       htmlrefpub = depmod.get_variable(pkgconfig: 'htmlrefpub', default_value: '')
       htmlrefdir = depmod.get_variable(pkgconfig: 'htmlrefdir', default_value: '')
     endif
-    if htmlrefpub == ''
-      htmlrefpub = htmlrefdir
-    elif htmlrefdir == ''
-      htmlrefdir = htmlrefpub
-    endif
-    doxygen_tagfiles += ' "' + doxytagfile + '=' + htmlrefpub + '"'
+    if doxytagfile != ''
+      if htmlrefpub == ''
+        htmlrefpub = htmlrefdir
+      elif htmlrefdir == ''
+        htmlrefdir = htmlrefpub
+      endif
+      doxygen_tagfiles += ' "' + doxytagfile + '=' + htmlrefpub + '"'
 
-    # Doxygen <= 1.8.15
-    docinstall_flags += ['-l', doxytagfile.split('/')[-1] + '@' + htmlrefdir]
-    if htmlrefpub != htmlrefdir
-      # Doxygen >= 1.8.16
-      docinstall_flags += ['-l', 's@' + htmlrefpub + '@' + htmlrefdir]
+      # Doxygen <= 1.8.15
+      docinstall_flags += ['-l', doxytagfile.split('/')[-1] + '@' + htmlrefdir]
+      if htmlrefpub != htmlrefdir
+        # Doxygen >= 1.8.16
+        docinstall_flags += ['-l', 's@' + htmlrefpub + '@' + htmlrefdir]
+      endif
     endif
   endif
 endforeach

--- a/meson.build
+++ b/meson.build
@@ -113,8 +113,11 @@ endif
 mm_common_get = find_program('mm-common-get', required: false)
 
 if maintainer_mode and not mm_common_get.found()
-  error('Maintainer mode requires the \'mm-common-get\' command.\n' +
-        'Use \'-Dmaintainer-mode=false\' or install the \'mm-common\' package, version 1.0.0 or higher')
+  message('Maintainer mode requires the \'mm-common-get\' command. If it is not found,\n' +
+          'use \'-Dmaintainer-mode=false\' or install the \'mm-common\' package, version 1.0.0 or higher.')
+  # If meson --wrap-mode != forcefallback, Meson falls back to the mm-common
+  # subproject only if mm-common-get is required.
+  mm_common_get = find_program('mm-common-get', required: true)
 endif
 
 perl = find_program('perl', required: build_documentation)
@@ -247,13 +250,16 @@ if can_add_dist_script
 endif
 
 if meson.is_subproject()
+  pkgconfig_vars = {
+    'htmlrefdir': install_prefix / install_docdir / 'reference' / 'html',
+    'htmlrefpub': 'http://library.gnome.org/devel/libsigc++/unstable/'
+  }
+  if build_documentation
+    pkgconfig_vars += {'doxytagfile': tag_file.full_path()}
+  endif
   sigcxx_dep = declare_dependency(
     dependencies: sigcxx_own_dep,
-    variables: {
-      'doxytagfile': tag_file.full_path(),
-      'htmlrefdir': install_prefix / install_docdir / 'reference' / 'html',
-      'htmlrefpub': 'http://library.gnome.org/devel/libsigc++/unstable/'
-    }
+    variables: pkgconfig_vars,
   )
 
   # A main project that looks for sigcxx_pcname.pc shall find sigcxx_dep.


### PR DESCRIPTION
This PR fixes 2/3 of issue #71.

 - Fallback for find_program('mm-common-get', required: false) does not work. If the program is not required Meson prefer not using the fallback subproject. Changing it to find_program('mm-common-get', required: maintainer_mode) would make more sense since you error() just below anyway.
 - When disabling documentation, 'doxytagfile': tag_file.full_path() fails because tag_file is not defined.

I'm not so sure about the last 1/3

 - Building doc requires many extra deps (perl, etc), would be nice to make that optinal by default using a feature option that defaults to auto.

Is documentation a feature? Some C packages (glib, gtk, etc.) control the documentation
with a boolean option with default value `false`. There once was a glibmm issue
where one of the complaints was that documentation is not built by default when you
build from a tarball. It's not easy making everyone happy when it comes to what
to build by default.

What do you say about adding a 4th choice to the build-documentation option:
`build-documentation=if-maintainer-mode-and-dependencies-found`, and let that be the
default value?
