### PR TITLE
Add missing perfect forwarding in bound_mem_functor::operator()

### DIFF
--- a/sigc++/functors/mem_fun.h
+++ b/sigc++/functors/mem_fun.h
@@ -149,7 +149,9 @@ public:
    */
   decltype(auto) operator()(type_trait_take_t<T_arg>... a) const
   {
-    return std::invoke(this->func_ptr_, obj_.invoke(), a...);
+    return std::invoke(
+      this->func_ptr_, obj_.invoke(),
+      std::forward<type_trait_take_t<T_arg>>(a)...);
   }
 
   // protected:

--- a/sigc++/functors/mem_fun.h
+++ b/sigc++/functors/mem_fun.h
@@ -113,7 +113,7 @@ public:
    */
   decltype(auto) operator()(obj_type_with_modifier& obj, type_trait_take_t<T_arg>... a) const
   {
-    return std::invoke(func_ptr_, obj, a...);
+    return std::invoke(func_ptr_, obj, std::forward<type_trait_take_t<T_arg>>(a)...);
   }
 
 protected:

--- a/sigc++/functors/ptr_fun.h
+++ b/sigc++/functors/ptr_fun.h
@@ -92,7 +92,9 @@ public:
    * @param a Arguments to be passed on to the function.
    * @return The return value of the function invocation.
    */
-  T_return operator()(type_trait_take_t<T_args>... a) const { return std::invoke(func_ptr_, a...); }
+  T_return operator()(type_trait_take_t<T_args>... a) const {
+    return std::invoke(func_ptr_, std::forward<type_trait_take_t<T_args>>(a)...);
+  }
 };
 
 /** Creates a functor of type sigc::pointer_functor which wraps an existing non-member function.

--- a/tests/test_rvalue_ref.cc
+++ b/tests/test_rvalue_ref.cc
@@ -16,6 +16,12 @@ struct foo
   void operator()(MoveableStruct&& /* x */) { result_stream << "foo(MoveableStruct&&)"; }
 };
 
+struct A
+{
+  void foo(MoveableStruct &&) { result_stream << "A::foo(MoveableStruct&&)"; }
+};
+
+
 } // end anonymous namespace
 
 void
@@ -40,6 +46,17 @@ test_slot()
   util->check_result(result_stream, "foo(MoveableStruct&&)");
 }
 
+void
+test_mem_fun()
+{
+  sigc::slot<void(MoveableStruct &&)> slot;
+  A a;
+  slot = sigc::mem_fun(a, &A::foo);
+  MoveableStruct x;
+  slot(std::move(x));
+  util->check_result(result_stream, "A::foo(MoveableStruct&&)");
+}
+
 int
 main(int argc, char* argv[])
 {
@@ -49,6 +66,7 @@ main(int argc, char* argv[])
 
   test_signal();
   test_slot();
+  test_mem_fun();
 
   return util->get_result_and_delete_instance() ? EXIT_SUCCESS : EXIT_FAILURE;
 } // end main()

--- a/tests/test_rvalue_ref.cc
+++ b/tests/test_rvalue_ref.cc
@@ -21,6 +21,9 @@ struct A
   void foo(MoveableStruct &&) { result_stream << "A::foo(MoveableStruct&&)"; }
 };
 
+void boo(MoveableStruct &&) {
+  result_stream << "boo(MoveableStruct&&)";
+}
 
 } // end anonymous namespace
 
@@ -49,12 +52,33 @@ test_slot()
 void
 test_mem_fun()
 {
+  sigc::slot<void(A &, MoveableStruct &&)> slot;
+  A a;
+  slot = sigc::mem_fun(&A::foo);
+  MoveableStruct x;
+  slot(a, std::move(x));
+  util->check_result(result_stream, "A::foo(MoveableStruct&&)");
+}
+
+void
+test_bound_mem_fun()
+{
   sigc::slot<void(MoveableStruct &&)> slot;
   A a;
   slot = sigc::mem_fun(a, &A::foo);
   MoveableStruct x;
   slot(std::move(x));
   util->check_result(result_stream, "A::foo(MoveableStruct&&)");
+}
+
+void
+test_ptr_fun()
+{
+  sigc::slot<void(MoveableStruct &&)> slot;
+  slot = sigc::ptr_fun(&boo);
+  MoveableStruct x;
+  slot(std::move(x));
+  util->check_result(result_stream, "boo(MoveableStruct&&)");
 }
 
 int
@@ -66,7 +90,9 @@ main(int argc, char* argv[])
 
   test_signal();
   test_slot();
+  test_bound_mem_fun();
   test_mem_fun();
+  test_ptr_fun();
 
   return util->get_result_and_delete_instance() ? EXIT_SUCCESS : EXIT_FAILURE;
 } // end main()


### PR DESCRIPTION
This is a missed addition to the commit that allowed rvalue references
in slot parameters.