### PR TITLE
sigc++config.h.*: Update and clean up a bit for Visual Studio

### DIFF
--- a/sigc++config.h.cmake
+++ b/sigc++config.h.cmake
@@ -33,7 +33,7 @@
 
 #ifdef SIGC_MSC
 /*
- * MS VC7 Warning 4251 says that the classes to any member objects in an
+ * Visual C++ Warning C4251 says that the classes to any member objects in an
  * exported class must also be exported.  Some of the libsigc++
  * template classes contain std::list members.  MS KB article 168958 says
  * that it's not possible to export a std::list instantiation due to some

--- a/sigc++config.h.cmake
+++ b/sigc++config.h.cmake
@@ -46,11 +46,6 @@
  */
 # pragma warning(disable:4251)
 
-#if (_MSC_VER < 1900) && !defined (noexcept)
-#define _ALLOW_KEYWORD_MACROS 1
-#define noexcept _NOEXCEPT
-#endif
-
 #else /* SIGC_MSC */
 
 #endif /* !SIGC_MSC */

--- a/sigc++config.h.in
+++ b/sigc++config.h.in
@@ -46,11 +46,6 @@
  */
 #pragma warning(disable : 4251)
 
-#if (_MSC_VER < 1900) && !defined(noexcept)
-#define _ALLOW_KEYWORD_MACROS 1
-#define noexcept _NOEXCEPT
-#endif
-
 #else /* SIGC_MSC */
 
 #endif /* !SIGC_MSC */

--- a/sigc++config.h.in
+++ b/sigc++config.h.in
@@ -33,7 +33,7 @@
 
 #ifdef SIGC_MSC
 /*
- * MS VC7 Warning 4251 says that the classes to any member objects in an
+ * Visual C++ Warning C4251 says that the classes to any member objects in an
  * exported class must also be exported.  Some of the libsigc++
  * template classes contain std::list members.  MS KB article 168958 says
  * that it's not possible to export a std::list instantiation due to some

--- a/sigc++config.h.meson
+++ b/sigc++config.h.meson
@@ -36,7 +36,7 @@
 
 #ifdef SIGC_MSC
 /*
- * MS VC7 Warning 4251 says that the classes to any member objects in an
+ * Visual C++ Warning C4251 says that the classes to any member objects in an
  * exported class must also be exported.  Some of the libsigc++
  * template classes contain std::list members.  MS KB article 168958 says
  * that it's not possible to export a std::list instantiation due to some

--- a/sigc++config.h.meson
+++ b/sigc++config.h.meson
@@ -49,11 +49,6 @@
  */
 #pragma warning(disable : 4251)
 
-#if (_MSC_VER < 1900) && !defined(noexcept)
-#define _ALLOW_KEYWORD_MACROS 1
-#define noexcept _NOEXCEPT
-#endif
-
 #else /* SIGC_MSC */
 
 #endif /* !SIGC_MSC */


### PR DESCRIPTION
Hi,

This attempts to clean up and update these `sigc++config.h.*` files a bit in regards to Visual Studio:

* Drop the workaround for using `noexcept`, since we require Visual Studio 2017 or later for libsigc++-3.x.
* Sadly, the `warning C4251` in the comments still applies today, and attempting to try to see whether we can export `std::list` can risk breaking ABI, so update the comment there.

---
Do we still have any libsigc++-2.x versions beyond 2.12?  If so, I think we could just drop VS2013 support, since the latest C++11 releases of items that use libsigc++-2.x would actually require VS2015 (or even VS2017 for libxml++-3.x) or later.

---

With blessings, thank you!