### PR TITLE
Zig build + CI test

### DIFF
--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -1,0 +1,38 @@
+name: "CI: zig build"
+
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        targets:
+          - x86_64-linux-gnu
+          - x86_64-linux-musl
+          - x86-linux-gnu
+          - x86-linux-musl
+          - aarch64-linux-gnu
+          - aarch64-linux-musl
+          - riscv64-linux-musl
+          - mipsel-linux-musl
+          - mips-linux-musl
+          - powerpc64-linux-musl
+          - x86_64-macos
+          - aarch64-macos
+          - x86_64-windows
+          - x86-windows
+          - aarch64-windows
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: master
+
+      - name: Build Summary ${{ matrix.targets }}
+        run: zig build -DTests --summary all -freference-trace -Dtarget=${{ matrix.targets }}

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ Makefile.in
 /sigc++config.h
 /sigc++-*.pc
 /stamp-h?
+zig-cache/
+zig-out/
 untracked/build_scripts/
 untracked/docs/
 *.pro.user

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,140 @@
+const std = @import("std");
+const FileSource = std.Build.FileSource;
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const tests = b.option(bool, "Tests", "Build tests [default: false]") orelse false;
+
+    const config = b.addConfigHeader(.{
+        .style = .{
+            .cmake = .{ .path = "sigc++config.h.cmake" },
+        },
+        .include_path = "sigc++config.h",
+    }, .{
+        .SIGCXX_DISABLE_DEPRECATED = null,
+        .SIGC_DLL = if (target.isWindows()) {} else null,
+        ._ALLOW_KEYWORD_MACROS = if (target.getAbi() == .msvc) "1" else null,
+    });
+    const lib = b.addStaticLibrary(.{
+        .name = "sigc++",
+        .target = target,
+        .optimize = optimize,
+    });
+    lib.addConfigHeader(config);
+    lib.addIncludePath(".");
+    lib.addCSourceFiles(&.{
+        "sigc++/connection.cc",
+        "sigc++/functors/slot_base.cc",
+        "sigc++/signal_base.cc",
+        "sigc++/trackable.cc",
+    }, cxxFlags);
+    lib.linkLibCpp();
+    lib.installHeadersDirectoryOptions(.{
+        .source_dir = FileSource.relative("sigc++"),
+        .install_dir = .header,
+        .install_subdir = "sigc++",
+        .exclude_extensions = &.{
+            "am",
+            "gitignore",
+            "build",
+            "cc",
+            "txt",
+        },
+    });
+
+    b.installArtifact(lib);
+
+    if (tests) {
+        buildTest(b, .{
+            .path = "examples/hello_world.cc",
+            .lib = lib,
+        });
+        buildTest(b, .{
+            .path = "examples/member_method.cc",
+            .lib = lib,
+        });
+        buildTest(b, .{
+            .path = "tests/test_accum_iter.cc",
+            .lib = lib,
+        });
+        buildTest(b, .{
+            .path = "tests/test_bind.cc",
+            .lib = lib,
+        });
+        buildTest(b, .{
+            .path = "tests/test_compose.cc",
+            .lib = lib,
+        });
+        buildTest(b, .{
+            .path = "tests/test_accumulated.cc",
+            .lib = lib,
+        });
+        buildTest(b, .{
+            .path = "tests/test_hide.cc",
+            .lib = lib,
+        });
+        buildTest(b, .{
+            .path = "tests/test_slot.cc",
+            .lib = lib,
+        });
+        buildTest(b, .{
+            .path = "tests/test_tuple_start.cc",
+            .lib = lib,
+        });
+        buildTest(b, .{
+            .path = "tests/test_tuple_transform_each.cc",
+            .lib = lib,
+        });
+        buildTest(b, .{
+            .path = "tests/test_visit_each.cc",
+            .lib = lib,
+        });
+        buildTest(b, .{
+            .path = "tests/test_weak_raw_ptr.cc",
+            .lib = lib,
+        });
+    }
+}
+const cxxFlags: []const []const u8 = &.{
+    "-Wall",
+    "-Wextra",
+    "-Werror",
+};
+fn buildTest(b: *std.Build, info: BuildInfo) void {
+    const test_exe = b.addExecutable(.{
+        .name = info.filename(),
+        .optimize = info.lib.optimize,
+        .target = info.lib.target,
+    });
+    for (info.lib.include_dirs.items) |include| {
+        test_exe.include_dirs.append(include) catch {};
+    }
+    test_exe.addCSourceFile(info.path, cxxFlags);
+    test_exe.addCSourceFile("tests/testutilities.cc", cxxFlags);
+    test_exe.linkLibrary(info.lib);
+    test_exe.linkLibCpp();
+    b.installArtifact(test_exe);
+
+    const run_cmd = b.addRunArtifact(test_exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    const run_step = b.step(
+        b.fmt("{s}", .{info.filename()}),
+        b.fmt("Run the {s} test", .{info.filename()}),
+    );
+    run_step.dependOn(&run_cmd.step);
+}
+
+const BuildInfo = struct {
+    lib: *std.Build.CompileStep,
+    path: []const u8,
+
+    fn filename(self: BuildInfo) []const u8 {
+        var split = std.mem.split(u8, std.fs.path.basename(self.path), ".");
+        return split.first();
+    }
+};

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,5 @@
+.{
+    .name = "sigc++",
+    .version = "2.3.1",
+    .license = "LGPLv3",
+}


### PR DESCRIPTION
Need zig [v0.11 or higher](https://ziglang.org/download) with pkg manager (for C++ [`zig c++`], uses `libcxx + libcxxabi + libunwind` only).

Release date?
See: https://github.com/ziglang/zig/milestone/17


### More info about `zig-pkg`

- https://github.com/ziglang/zig/pull/14265
- https://devlog.hexops.com/2023/mach-ecosystem-c-libraries/
- https://kassane.github.io/2023/05/03/zig-pkg/
- https://github.com/catdevnull/awesome-zig#cc-libraries-packaged-for-zig (also boost-lib is in progress of being ported)