### PR TITLE
slot|signal: static_assert not using R,T... syntax

### DIFF
--- a/sigc++/functors/slot.h
+++ b/sigc++/functors/slot.h
@@ -194,7 +194,9 @@ struct slot_call
  */
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 template<typename T_return, typename... T_arg>
-class slot;
+class slot final {
+  static_assert(sizeof...(T_arg) < 0, "The slot<R, T...> syntax has been removed. Use the slot<R(T...)> syntax.");
+};
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 template<typename T_return, typename... T_arg>

--- a/sigc++/signal.h
+++ b/sigc++/signal.h
@@ -581,7 +581,9 @@ public:
  */
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 template<typename T_return, typename... T_arg>
-class signal;
+class signal final {
+  static_assert(sizeof...(T_arg) < 0, "The signal<R, T...> syntax has been removed. Use the signal<R(T...)> syntax.");
+};
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 template<typename T_return, typename... T_arg>


### PR DESCRIPTION
This can lead to clearer errors by explaining the user's error, not just saying they used an incomplete type (why is it incomplete?). I don't use only static_assert(false) because that's ill-formed before C++23, AFAIK, & even if it's OK in some cases I don't grok which... so hope this works

My hope is that by using the weird `sizeof` comparison, it bypasses the issue with `static_assert(false)`, based on topics like this:

* https://stackoverflow.com/questions/40783712/disable-template-but-allow-specializations

Tests build and run fine on `g++ (Debian 13.2.0-6) 13.2.0` but I would appreciate more coverage on other compilers.

If we do this, we should do equivalent for `Glib::SignalProxy` in `glibmm`.

Fixes https://github.com/libsigcplusplus/libsigcplusplus/issues/86