### PR TITLE
Add signal connect helpers

### DIFF
--- a/sigc++/filelist.am
+++ b/sigc++/filelist.am
@@ -27,6 +27,7 @@ sigc_public_h =				\
 	scoped_connection.h \
 	signal.h \
 	signal_base.h			\
+	signal_connect.h		\
 	slot.h			\
 	trackable.h			\
 	tuple-utils/tuple_cdr.h \

--- a/sigc++/meson.build
+++ b/sigc++/meson.build
@@ -25,6 +25,7 @@ sigc_h_files = [
   'scoped_connection.h',
   'signal.h',
   'signal_base.h',
+  'signal_connect.h',
   'slot.h',
   'trackable.h',
   'type_traits.h',

--- a/sigc++/sigc++.h
+++ b/sigc++/sigc++.h
@@ -119,6 +119,7 @@
 #include <sigc++/connection.h>
 #include <sigc++/scoped_connection.h>
 #include <sigc++/trackable.h>
+#include <sigc++/signal_connect.h>
 #include <sigc++/adaptors/adaptors.h>
 #include <sigc++/functors/functors.h>
 

--- a/sigc++/signal_base.h
+++ b/sigc++/signal_base.h
@@ -281,6 +281,22 @@ protected:
  * a @ref sigc::slot<T_return(T_arg...)> "sigc::slot"
  * and connected to a signal. See @ref slot "Slots" and
  * @ref sigc::signal_with_accumulator::connect() "sigc::signal::connect()".
+ *
+ * Use @ref sigc::signal_connect() to connect a method or function to a signal
+ * without having to explicitly write the required template parameters in case
+ * of method or function overloading.
+ *
+ * @code
+ * sigc::signal<void(int)> sig;
+ * void fun(int);
+ * void fun(double);
+ * sig.connect(sigc::ptr_fun<void, int>(fun));
+ * // or more simply:
+ * sigc::signal_connect(sig, fun);
+ * @endcode
+ *
+ * It can also be used as a replacement for calling signal::connect() with a
+ * sigc::mem_fun() or a sigc::ptr_fun().
  */
 
 // TODO: When we can break ABI, let signal_base derive from trackable again,

--- a/sigc++/signal_connect.h
+++ b/sigc++/signal_connect.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024, The libsigc++ Development Team
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ */
+
+#ifndef SIGC_SIGNAL_CONNECT_H
+#define SIGC_SIGNAL_CONNECT_H
+
+#include <sigc++/signal.h>
+#include <sigc++/functors/ptr_fun.h>
+#include <sigc++/functors/mem_fun.h>
+
+namespace sigc
+{
+
+/** Connect a function to a signal
+ * @param signal The signal to connect to.
+ * @param fun The function that should be wrapped.
+ * @return A connection.
+ *
+ * @ingroup signal
+ */
+template<typename T_return, typename... T_arg>
+inline connection
+signal_connect(signal<T_return(T_arg...)>& signal, T_return (*fun)(T_arg...))
+{
+  return signal.connect(ptr_fun<T_return, T_arg...>(fun));
+}
+
+/** Connect a non-const method to a signal
+ * @param signal The signal to connect to.
+ * @param obj Reference to object instance the functor should operate on.
+ * @param fun Pointer to method that should be wrapped.
+ * @return A connection.
+ *
+ * @ingroup signal
+ */
+template<typename T_return, typename T_obj, typename... T_arg>
+inline connection
+signal_connect(signal<T_return(T_arg...)>& signal, /**/ T_obj& obj, T_return (T_obj::*fun)(T_arg...))
+{
+  return signal.connect(mem_fun<T_return, T_obj, T_obj, T_arg...>(obj, fun));
+}
+
+/** Connect a const method to a signal
+ * @param signal The signal to connect to.
+ * @param obj Reference to object instance the functor should operate on.
+ * @param fun Pointer to method that should be wrapped.
+ * @return A connection.
+ *
+ * @ingroup signal
+ */
+#if SIGC_MSC
+/* MSVC needs to distinguish object's class and method's class (using the
+ * template parameter T_obj2) to avoid raising error C2672 (no matching
+ * overloaded function found) when signal_connect(...) is called with a
+ * const object.
+ */
+template<typename T_return, typename T_obj, typename T_obj2, typename... T_arg>
+inline connection
+signal_connect(signal<T_return(T_arg...)>& signal, /*const*/ T_obj& obj, T_return (T_obj2::*fun)(T_arg...) const)
+{
+  return signal.connect(mem_fun<T_return, T_obj, T_obj, T_arg...>(obj, fun));
+}
+#else
+template<typename T_return, typename T_obj, typename... T_arg>
+inline connection
+signal_connect(signal<T_return(T_arg...)>& signal, /*const*/ T_obj& obj, T_return (T_obj::*fun)(T_arg...) const)
+{
+  return signal.connect(mem_fun<T_return, T_obj, T_obj, T_arg...>(obj, fun));
+}
+#endif
+
+} /* namespace sigc */
+
+#endif /* SIGC_SIGNAL_CONNECT_H */
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ set (TEST_SOURCE_FILES
   test_rvalue_ref.cc
   test_scoped_connection.cc
   test_signal.cc
+  test_signal_connect.cc
   test_signal_move.cc
   test_size.cc
   test_slot.cc

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -49,6 +49,7 @@ check_PROGRAMS = \
   test_rvalue_ref \
   test_scoped_connection \
   test_signal \
+  test_signal_connect \
   test_signal_move \
   test_size \
   test_slot \
@@ -95,6 +96,7 @@ test_retype_return_SOURCES   = test_retype_return.cc $(sigc_test_util)
 test_rvalue_ref_SOURCES      = test_rvalue_ref.cc $(sigc_test_util)
 test_scoped_connection_SOURCES = test_scoped_connection.cc $(sigc_test_util)
 test_signal_SOURCES          = test_signal.cc $(sigc_test_util)
+test_signal_connect_SOURCES  = test_signal_connect.cc $(sigc_test_util)
 test_signal_move_SOURCES     = test_signal_move.cc $(sigc_test_util)
 test_size_SOURCES            = test_size.cc $(sigc_test_util)
 test_slot_SOURCES            = test_slot.cc $(sigc_test_util)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -31,6 +31,7 @@ test_programs = [
   [[], 'test_rvalue_ref', ['test_rvalue_ref.cc', 'testutilities.cc']],
   [[], 'test_scoped_connection', ['test_scoped_connection.cc', 'testutilities.cc']],
   [[], 'test_signal', ['test_signal.cc', 'testutilities.cc']],
+  [[], 'test_signal_connect', ['test_signal_connect.cc', 'testutilities.cc']],
   [[], 'test_signal_move', ['test_signal_move.cc', 'testutilities.cc']],
   [[], 'test_size', ['test_size.cc', 'testutilities.cc']],
   [[], 'test_slot', ['test_slot.cc', 'testutilities.cc']],

--- a/tests/test_signal_connect.cc
+++ b/tests/test_signal_connect.cc
@@ -1,0 +1,144 @@
+/* Copyright 2024, The libsigc++ Development Team
+ *  Assigned to public domain.  Use as you wish without restriction.
+ */
+
+#include "testutilities.h"
+#include <sigc++/trackable.h>
+#include <sigc++/signal_connect.h>
+
+namespace
+{
+
+TestUtilities* util = nullptr;
+std::ostringstream result_stream;
+
+void
+fun(int i)
+{
+  result_stream << "fun(int " << i << ")";
+}
+
+[[maybe_unused]]
+void
+fun(double d)
+{
+  result_stream << "fun(double " << d << ")";
+}
+
+struct foo : public sigc::trackable
+{
+  void fun_nonconst(int i)
+  {
+    result_stream << "foo::fun_nonconst(int " << i << ")";
+  }
+
+  void fun_nonconst(double d)
+  {
+    result_stream << "foo::fun_nonconst(double " << d << ")";
+  }
+
+  void fun_const(int i) const
+  {
+    result_stream << "foo::fun_const(int " << i << ")";
+  }
+
+  void fun_const(double d) const
+  {
+    result_stream << "foo::fun_const(double " << d << ")";
+  }
+};
+
+struct bar : public sigc::trackable
+{
+  void fun_nonconst(int i, int j)
+  {
+    result_stream << "bar::fun_nonconst(int " << i << ", int " << j << ")";
+  }
+
+  void fun_nonconst(int i, double j)
+  {
+    result_stream << "bar::fun_nonconst(int " << i << ", double " << j << ")";
+  }
+
+  void fun_const(int i, int j) const
+  {
+    result_stream << "bar::fun_const(int " << i << ", int " << j << ")";
+  }
+
+  void fun_const(int i, double j) const
+  {
+    result_stream << "bar::fun_const(int " << i << ", double " << j << ")";
+  }
+};
+
+void
+test_signal_connect_fun()
+{
+  sigc::signal<void(int)> signal;
+
+  sigc::signal_connect(signal, &fun);
+
+  signal.emit(42);
+  util->check_result(result_stream, "fun(int 42)");
+}
+
+void
+test_signal_connect_method_nonconst()
+{
+  sigc::signal<void(int)> signal;
+  foo f;
+
+  sigc::signal_connect(signal, f, &foo::fun_nonconst);
+
+  signal.emit(42);
+  util->check_result(result_stream, "foo::fun_nonconst(int 42)");
+}
+
+void
+test_signal_connect_method_const()
+{
+  sigc::signal<void(int)> signal;
+  foo f;
+
+  sigc::signal_connect(signal, f, &foo::fun_const);
+
+  signal.emit(42);
+  util->check_result(result_stream, "foo::fun_const(int 42)");
+}
+
+void
+test_signal_connect_method_const_with_const_object()
+{
+  sigc::signal<void(int)> signal;
+  const foo f;
+
+  sigc::signal_connect(signal, f, &foo::fun_const);
+
+  signal.emit(42);
+  util->check_result(result_stream, "foo::fun_const(int 42)");
+}
+
+void
+test_signal_connect_method()
+{
+  test_signal_connect_method_nonconst();
+  test_signal_connect_method_const();
+  test_signal_connect_method_const_with_const_object();
+}
+
+} // end anonymous namespace
+
+int
+main(int argc, char* argv[])
+{
+  util = TestUtilities::get_instance();
+
+  if (!util->check_command_args(argc, argv))
+    return util->get_result_and_delete_instance() ? EXIT_SUCCESS : EXIT_FAILURE;
+
+  test_signal_connect_fun();
+
+  test_signal_connect_method();
+
+  return util->get_result_and_delete_instance() ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
After discussion in #104, there are finally more than 3 versions of `signc::signal_connect(...)`:
* 1 for lambdas and std::function;
* 1 using `sigc::ptr_fun(...)` for function pointers;
* 1 using `sigc::bind(sigc::ptr_fun<...>(...)` for function pointers with partially or totally bound arguments;
* 4 `sigc::mem_fun(...)` for methods (one for each the non-cv one and the 3 cv ones);
* 4 `sigc::bind(sigc::mem_fun<...>(...)` for  methods (for the same reason).

I think the test program can be used as a good showcase (instead of writing an example program) and I don't have any changes for the documentation yet.

**But** I face 2 problems (hence the WIP prefix):

1. Clang does not accept the `sigc::mem_fun(...)` with overloaded methods while GCC does.
2. Clang and GCC do not accept `sigc::bind(sigc::mem_fun<...>(...)` while they accept `sigc::bind(sigc::ptr_fun<...>(...)`.

By GCC, I mean GCC 13.3 and 14.2 and for Clang, I used 16.0.6, 17.0.6, and 18.1.8.

For 1, the message is:
```shell
.../libsigcplusplus/sigc++/signal_connect.h:63:1: note: candidate template ignored: couldn't infer template argument 'T_obj2'
   63 | signal_connect(signal<T_return(T_arg...)>& signal, /**/ T_obj& obj, T_return (T_obj2::*fun)(T_arg...))
      | ^
```

and I can not find a way to get around it... I can only think that Clang consider implicit conversion while searching a candidate while GCC does not...

for 2, the messages are (for GCC):

```shell
.../libsigcplusplus/sigc++/signal_connect.h:131:1: note: candidate: ‘template<class T_return, class T_obj, class T_obj2, class ... T_unbound, class T_bound0, class ... T_boundn> sigc::connection sigc::signal_connect(signal<T_return(T_arg ...)>&, T_obj&, T_return (T_obj2::*)(T_unbound ..., T_bound0, T_boundn ...), T_bound0&&, T_boundn&& ...)’
  131 | signal_connect(signal<T_return(T_unbound...)>& signal, /**/ T_obj& obj, T_return (T_obj2::*fun)(T_unbound..., T_bound0, T_boundn...), T_bound0&& bound0, T_boundn&&... boundn)
      | ^~~~~~~~~~~~~~
.../libsigcplusplus/sigc++/signal_connect.h:131:1: note:   template argument deduction/substitution failed:
.../libsigcplusplus/tests/test_signal_connect.cc:128:23: note:   couldn’t deduce template parameter ‘T_obj2’
  128 |   sigc::signal_connect(signal, b, &bar::print, 1);
      |   ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
```

and (for Clang):

```shell
.../libsigcplusplus/tests/test_signal_connect.cc:128:3: error: no matching function for call to 'signal_connect'
  128 |   sigc::signal_connect(signal, b, &bar::print, 1);
      |   ^~~~~~~~~~~~~~~~~~~~
.../libsigcplusplus/sigc++/signal_connect.h:131:1: note: candidate template ignored: couldn't infer template argument 'T_obj2'
  131 | signal_connect(signal<T_return(T_unbound...)>& signal, /**/ T_obj& obj, T_return (T_obj2::*fun)(T_unbound..., T_bound0, T_boundn...), T_bound0&& bound0, T_boundn&&... boundn)
      | ^
```

I can not figure what make one build and not the other...

So, this PR has 2 commits: the first with all but the `sigc:bind` versions (but still with problem 1), the second with the `sigc:bind` versions of `sigc::signal_connect(...)`. To make the later fails, the calls to `sigc::signal_connect(...)` in `test_signal_connect_partial_bind_method()` and in `test_signal_connect_total_bind_method()` have to be uncommented.

Any feedback or hints are welcome

best regards
