### PR TITLE
build-pdf: Prevent infinite loop in dblatex

### DIFF
--- a/tools/tutorial-custom-cmd.py
+++ b/tools/tutorial-custom-cmd.py
@@ -112,6 +112,7 @@ def dblatex():
     '-P', 'paper.type=a4paper',
     '-P', 'doc.collab.show=1',
     '-P', 'latex.output.revhistory=0',
+    '-P', 'latex.engine.options="-halt-on-error"',
   ]
 
   cmd = [


### PR DESCRIPTION
If a font (usually from texlive) is missing, dblatex goes on an infinite loop and prints no error message (not even in logs).

Issue happened because a dependency update on my side might be missing from dblatex package. In any case, should fail and print something useful, not go on forever. Failing on error really should be a dblatex built-in default, but upstream seems dead, therefore adding safety here.

Should be applied on both 2.12.x and 3.x branches. Tested with release libsigc 2.12.1 and 3.6.0.