### PR TITLE
Further NMake Makefile improvements (2.12 branch)

### DIFF
--- a/MSVC_NMake/MSVC-Builds.md
+++ b/MSVC_NMake/MSVC-Builds.md
@@ -17,13 +17,10 @@ targets:
 
 * `all`, `examples`: (or no target specified): The libsigc++ DLL and the example programs.
 * `tests`: The libsigc++ DLL and the test programs.
-* `benchmark`: The libsigc++ DLL and the benchmark program, the Boost C++ headers should be found in one of the paths that are in`%INCLUDE%`.
-
-Building directly from a GIT checkout is now supported, provided that a `PERL`
-installation is present, along with the `m4` executable that can be optained
-by installing CygWin or MSYS2 (add the location of your `m4` executable to the
-end of your `%PATH%` and pass the `PERL` interpreter executable in your NMake
-command line by using `nmake /f Makefile.vc ... PERL=<path_to_PERL_interpreter_executable>`).
+* `benchmark`: The libsigc++ DLL and the benchmark program, the Boost C++ libraries are
+needed. The Boost C++ headers and .lib's should be found in one of the paths that are in
+`%INCLUDE%` and `%LIB%` respectively, or use BOOST_INCLUDEDIR and/or BOOST_LIBDIR to
+point to the paths where the Boost headers and .lib's can be found.
 
 The following are instructions for performing such a build.  A `clean` target is
 provided-it is recommended that one cleans the build and redo the build if any
@@ -37,13 +34,15 @@ generated.  This may be useful if one wants to re-generate the sources and heade
 from the m4 templates.
 
 Invoke the build by issuing the command:
-`nmake /f Makefile.vc CFG=[release|debug] [PREFIX=...] <option1=1 option2=1 ...>`
+`nmake /f Makefile.vc CFG=[release|debug] <option1=1 option2=1 ...>`
 where:
 
 * `CFG`: Required.  Choose from a `release` or `debug` build.  Note that
  all builds generate a `.pdb` file for each `.dll` and `.exe` built.
 
-* `PREFIX`: Optional.  Base directory of where the third-party headers, libraries
+Options that are supported for the build are as follows (all are optional unless
+noted):
+* PREFIX: Base directory of where the third-party headers, libraries
 and needed tools can be found, i.e. headers in `$(PREFIX)\include`,
 libraries in `$(PREFIX)\lib` and tools and DLLs in `$(PREFIX)\bin`.  If not
 specified, `$(PREFIX)` is set as `$(srcroot)\..\vs$(X)\$(platform)`, where
@@ -56,14 +55,27 @@ Visual Studio used, as follows:
   * 2022: `17`
   * 2026: `18`
 
-* Options, set by `<option>=1`:
-
-  * `BOOST_DLL`: When building the benchmark, link to a DLL build of the Boost
-libraries.  Required if your installation of the Boost libraries are built as DLLs.
-Note that debug builds must link to debug builds of Boost and release builds must
-link to release builds of Boost.
-
-  *  `STATIC`: Optional.  Set if building libsigc++ as a static library. Note that
+* BASE_INCLUDEDIR: Base directory where needed headers can be found; default
+is `$(PREFIX)\include`. Also see BOOST_INCLUDEDIR for more details on this.
+* BASE_LIBDIR: Base directory where needed .lib's are found; default is
+`$(PREFIX)\lib`. Also see BOOST_LIBDIR for more details on this.
+* BOOST_INCLUDEDIR: Directory where the Boost C++ headers, needed for the
+benchmark program, can be found, default is `$(BASE_INCLUDEDIR)`.
+You need to include the subdirectory for the Boost version you are using,
+if it is there. i.e. If you are using Boost-1.89, you need to set this to
+`BOOST_INCLUDEDIR=<some_include_dir>\boost-1_89`.
+* BOOST_LIBDIR: Directory where the needed .lib's for Boost can be found.
+Also note BOOST_DLL if you are building against Boost that are built as DLLs.
+* BOOST_DLL: Set to `1` when building the benchmark program, link to a DLL
+build of the Boost libraries.  Required if your installation of the Boost.
+libraries are built as DLLs. Note that debug builds must link to debug builds
+of Boost and release builds must link to release builds of Boost.
+* PERL, M4: Path to the PERL interpreter and `m4` tool if not already in `%PATH%`,
+PERL is needed for all builds, and m4 is needed for builds from a GIT checkout.
+Alternatively, for `m4`, use UNIX_TOOLS_BINDIR to point to the directory where the
+`m4` executable may be found, such as the `bin` directory of your Cygwin or
+MSYS2/MSYS64 installation.
+*  STATIC: Set to `1` if building libsigc++ as a static library. Note that
 for building items that use this static build, `/DLIBSIGCXX_STATIC`
 must be passed into the compiler flags.
 

--- a/MSVC_NMake/build-rules-msvc.mak
+++ b/MSVC_NMake/build-rules-msvc.mak
@@ -13,67 +13,67 @@
 # 	$(CC)|$(CXX) $(cflags) /Fo$(destdir) /c @<<
 # $<
 # <<
-{..\sigc++\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\}.obj:
+{..\sigc++\}.cc{$(OUTDIR)\$(SIGC_INTDIR)\}.obj:
 	@for %f in ($(base_built_cc) $(base_built_h)) do @if not exist ..\sigc++\%f if not exist ..\untracked\sigc++\%f if not exist $(@D)\sigc++\%f $(MAKE) /f Makefile.vc CFG=$(CFG) generate-sources
 	@for %f in ($(functors_built_cc) $(functors_built_h)) do @if not exist ..\sigc++\functors\%f if not exist ..\untracked\sigc++\functors\%f if not exist $(@D)\sigc++\functors\%f $(MAKE) /f Makefile.vc CFG=$(CFG) generate-sources
 	@for %f in ($(adaptors_built_cc) $(adaptors_built_h)) do @if not exist ..\sigc++\adaptors\%f if not exist ..\untracked\sigc++\adaptors\%f if not exist $(@D)\sigc++\adaptors\%f $(MAKE) /f Makefile.vc CFG=$(CFG) generate-sources
 	@for %f in ($(lambda_built_cc) $(lambda_built_h)) do @if not exist ..\sigc++\adaptors\lambda\%f if not exist ..\untracked\sigc++\adaptors\lambda\%f if not exist $(@D)\sigc++\adaptors\lambda\%f $(MAKE) /f Makefile.vc CFG=$(CFG) generate-sources
 	@if not exist .\sigc++config.h if not exist ..\untracked\MSVC_NMake\sigc++config.h $(MAKE) /f Makefile.vc CFG=$(CFG) sigc++config.h
 	@if not exist $(@D)\ md $(@D)
-	$(CXX) $(LIBSIGCPP_CFLAGS) /Fo$(@D)\ /Fd$(@D)\ /c @<<
+	$(CXX) $(CFLAGS) $(SIGC_DEFINES) $(SIGC_INCLUDES) /Fo$(@D)\ /Fd$(@D)\ /c @<<
 $<
 <<
 
-{..\sigc++\adaptors\lambda\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\}.obj:
+{..\sigc++\adaptors\lambda\}.cc{$(OUTDIR)\$(SIGC_INTDIR)\}.obj:
 	@for %f in ($(base_built_cc) $(base_built_h)) do @if not exist ..\sigc++\%f if not exist ..\untracked\sigc++\%f if not exist $(@D)\sigc++\%f $(MAKE) /f Makefile.vc CFG=$(CFG) generate-sources
 	@for %f in ($(functors_built_cc) $(functors_built_h)) do @if not exist ..\sigc++\functors\%f if not exist ..\untracked\sigc++\functors\%f if not exist $(@D)\sigc++\functors\%f $(MAKE) /f Makefile.vc CFG=$(CFG) generate-sources
 	@for %f in ($(adaptors_built_cc) $(adaptors_built_h)) do @if not exist ..\sigc++\adaptors\%f if not exist ..\untracked\sigc++\adaptors\%f if not exist $(@D)\sigc++\adaptors\%f $(MAKE) /f Makefile.vc CFG=$(CFG) generate-sources
 	@for %f in ($(lambda_built_cc) $(lambda_built_h)) do @if not exist ..\sigc++\adaptors\lambda\%f if not exist ..\untracked\sigc++\adaptors\lambda\%f if not exist $(@D)\sigc++\adaptors\lambda\%f $(MAKE) /f Makefile.vc CFG=$(CFG) generate-sources
 	@if not exist .\sigc++config.h if not exist ..\untracked\MSVC_NMake\sigc++config.h $(MAKE) /f Makefile.vc CFG=$(CFG) sigc++config.h
 	@if not exist $(@D)\ md $(@D)
-	$(CXX) $(LIBSIGCPP_CFLAGS) /Fo$(@D)\ /Fd$(@D)\ /c @<<
+	$(CXX) $(CFLAGS) $(SIGC_DEFINES) $(SIGC_INCLUDES) /Fo$(@D)\ /Fd$(@D)\ /c @<<
 $<
 <<
 
-{..\sigc++\functors\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\}.obj:
+{..\sigc++\functors\}.cc{$(OUTDIR)\$(SIGC_INTDIR)\}.obj:
 	@for %f in ($(base_built_cc) $(base_built_h)) do @if not exist ..\sigc++\%f if not exist ..\untracked\sigc++\%f if not exist $(@D)\sigc++\%f $(MAKE) /f Makefile.vc CFG=$(CFG) generate-sources
 	@for %f in ($(functors_built_cc) $(functors_built_h)) do @if not exist ..\sigc++\functors\%f if not exist ..\untracked\sigc++\functors\%f if not exist $(@D)\sigc++\functors\%f $(MAKE) /f Makefile.vc CFG=$(CFG) generate-sources
 	@for %f in ($(adaptors_built_cc) $(adaptors_built_h)) do @if not exist ..\sigc++\adaptors\%f if not exist ..\untracked\sigc++\adaptors\%f if not exist $(@D)\sigc++\adaptors\%f $(MAKE) /f Makefile.vc CFG=$(CFG) generate-sources
 	@for %f in ($(lambda_built_cc) $(lambda_built_h)) do @if not exist ..\sigc++\adaptors\lambda\%f if not exist ..\untracked\sigc++\adaptors\lambda\%f if not exist $(@D)\sigc++\adaptors\lambda\%f $(MAKE) /f Makefile.vc CFG=$(CFG) generate-sources
 	@if not exist .\sigc++config.h if not exist ..\untracked\MSVC_NMake\sigc++config.h $(MAKE) /f Makefile.vc CFG=$(CFG) sigc++config.h
 	@if not exist $(@D)\ md $(@D)
-	$(CXX) $(LIBSIGCPP_CFLAGS) /Fo$(@D)\ /Fd$(@D)\ /c @<<
+	$(CXX) $(CFLAGS) $(SIGC_DEFINES) $(SIGC_INCLUDES) /Fo$(@D)\ /Fd$(@D)\ /c @<<
 $<
 <<
 
-{..\untracked\sigc++\adaptors\lambda\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\}.obj:
+{..\untracked\sigc++\adaptors\lambda\}.cc{$(OUTDIR)\$(SIGC_INTDIR)\}.obj:
 	@for %f in ($(base_built_cc) $(base_built_h)) do @if not exist ..\sigc++\%f if not exist ..\untracked\sigc++\%f if not exist $(@D)\sigc++\%f $(MAKE) /f Makefile.vc CFG=$(CFG) generate-sources
 	@for %f in ($(functors_built_cc) $(functors_built_h)) do @if not exist ..\sigc++\functors\%f if not exist ..\untracked\sigc++\functors\%f if not exist $(@D)\sigc++\functors\%f $(MAKE) /f Makefile.vc CFG=$(CFG) generate-sources
 	@for %f in ($(adaptors_built_cc) $(adaptors_built_h)) do @if not exist ..\sigc++\adaptors\%f if not exist ..\untracked\sigc++\adaptors\%f if not exist $(@D)\sigc++\adaptors\%f $(MAKE) /f Makefile.vc CFG=$(CFG) generate-sources
 	@for %f in ($(lambda_built_cc) $(lambda_built_h)) do @if not exist ..\sigc++\adaptors\lambda\%f if not exist ..\untracked\sigc++\adaptors\lambda\%f if not exist $(@D)\sigc++\adaptors\lambda\%f $(MAKE) /f Makefile.vc CFG=$(CFG) generate-sources
 	@if not exist .\sigc++config.h if not exist ..\untracked\MSVC_NMake\sigc++config.h $(MAKE) /f Makefile.vc CFG=$(CFG) sigc++config.h
 	@if not exist $(@D)\ md $(@D)
-	$(CXX) $(LIBSIGCPP_CFLAGS) /Fo$(@D)\ /Fd$(@D)\ /c @<<
+	$(CXX) $(CFLAGS) $(SIGC_DEFINES) $(SIGC_INCLUDES) /Fo$(@D)\ /Fd$(@D)\ /c @<<
 $<
 <<
 
-{vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\sigc++\adaptors\lambda\}.cc{vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\}.obj:
+{$(OUTDIR)\$(SIGC_INTDIR)\sigc++\adaptors\lambda\}.cc{$(OUTDIR)\$(SIGC_INTDIR)\}.obj:
 	@for %f in ($(base_built_cc) $(base_built_h)) do @if not exist ..\sigc++\%f if not exist ..\untracked\sigc++\%f if not exist $(@D)\sigc++\%f $(MAKE) /f Makefile.vc CFG=$(CFG) generate-sources
 	@for %f in ($(functors_built_cc) $(functors_built_h)) do @if not exist ..\sigc++\functors\%f if not exist ..\untracked\sigc++\functors\%f if not exist $(@D)\sigc++\functors\%f $(MAKE) /f Makefile.vc CFG=$(CFG) generate-sources
 	@for %f in ($(adaptors_built_cc) $(adaptors_built_h)) do @if not exist ..\sigc++\adaptors\%f if not exist ..\untracked\sigc++\adaptors\%f if not exist $(@D)\sigc++\adaptors\%f $(MAKE) /f Makefile.vc CFG=$(CFG) generate-sources
 	@for %f in ($(lambda_built_cc) $(lambda_built_h)) do @if not exist ..\sigc++\adaptors\lambda\%f if not exist ..\untracked\sigc++\adaptors\lambda\%f if not exist $(@D)\sigc++\adaptors\lambda\%f $(MAKE) /f Makefile.vc CFG=$(CFG) generate-sources
 	@if not exist .\sigc++config.h if not exist ..\untracked\MSVC_NMake\sigc++config.h $(MAKE) /f Makefile.vc CFG=$(CFG) sigc++config.h
-	$(CXX) $(LIBSIGCPP_CFLAGS) /Fo$(@D)\ /Fd$(@D)\ /c @<<
+	$(CXX) $(CFLAGS) $(SIGC_DEFINES) $(SIGC_INCLUDES) /Fo$(@D)\ /Fd$(@D)\ /c @<<
 $<
 <<
 
 # Rules for building .lib files
-$(LIBSIGC_LIB): $(LIBSIGC_DLL)
+$(SIGC_LIB): $(SIGC_DLL)
 
-{.}.rc{vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\}.res:
+{.}.rc{$(OUTDIR)\$(SIGC_INTDIR)\}.res:
 	rc /fo$@ $<
 
-{..\untracked\MSVC_NMake\}.rc{vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\}.res:
+{..\untracked\MSVC_NMake\}.rc{$(OUTDIR)\$(SIGC_INTDIR)\}.res:
 	@if not exist $(@D)\ md $(@D)
 	rc /fo$@ $<
 
@@ -85,15 +85,15 @@ $(LIBSIGC_LIB): $(LIBSIGC_DLL)
 # <<
 # 	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;2
 !ifdef STATIC
-$(LIBSIGC_LIB): $(libsigc_OBJS)
+$(SIGC_LIB): $(libsigc_OBJS)
 	lib $(ARFLAGS) -out:$@ @<<
 $(libsigc_OBJS)
 <<
 !else
-$(LIBSIGC_LIB): $(LIBSIGC_DLL)
+$(SIGC_LIB): $(SIGC_DLL)
 
-$(LIBSIGC_DLL): $(libsigc_OBJS)
-	link /DLL $(LDFLAGS) /implib:$(LIBSIGC_LIB) -out:$@ @<<
+$(SIGC_DLL): $(libsigc_OBJS)
+	link /DLL $(LDFLAGS) /implib:$(SIGC_LIB) -out:$@ @<<
 $(libsigc_OBJS)
 <<
 	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;2
@@ -108,26 +108,26 @@ $(libsigc_OBJS)
 # 	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;1
 
 clean:
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.exe
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.dll
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.pdb
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.ilk
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.exp
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\*.lib
-	@-if exist vs$(VSVER)\$(CFG)\$(PLAT)\$(SIGC_TESTS_INTDIR) del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\$(SIGC_TESTS_INTDIR)\*.obj
-	@-if exist vs$(VSVER)\$(CFG)\$(PLAT)\$(SIGC_TESTS_INTDIR) del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\$(SIGC_TESTS_INTDIR)\*.pdb
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\$(SIGC_EX_INTDIR)\*.obj
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\$(SIGC_EX_INTDIR)\*.pdb
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\*.res
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\*.obj
-	@-del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\*.pdb
-	@-if exist vs$(VSVER)\$(CFG)\$(PLAT)\$(SIGC_TESTS_INTDIR) rd vs$(VSVER)\$(CFG)\$(PLAT)\$(SIGC_TESTS_INTDIR)
-	@-rd vs$(VSVER)\$(CFG)\$(PLAT)\$(SIGC_EX_INTDIR)
-	@-for %d in ($(sigc_m4_srcdirs)) do @for %x in (cc h) do @if exist vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\sigc++\%d\ del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\sigc++\%d\*.%x
-	@-for %x in (cc h) do @if exist vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\sigc++\ del /f /q vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\sigc++\*.%x
-	@-for %d in ($(sigc_m4_srcdirs)) do @rd vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\sigc++\%d
-	@-rd vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\sigc++
-	@-rd vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)
+	@-del /f /q $(OUTDIR)\*.exe
+	@-del /f /q $(OUTDIR)\*.dll
+	@-del /f /q $(OUTDIR)\*.pdb
+	@-del /f /q $(OUTDIR)\*.ilk
+	@-del /f /q $(OUTDIR)\*.exp
+	@-del /f /q $(OUTDIR)\*.lib
+	@-if exist $(OUTDIR)\$(SIGC_TESTS_INTDIR) del /f /q $(OUTDIR)\$(SIGC_TESTS_INTDIR)\*.obj
+	@-if exist $(OUTDIR)\$(SIGC_TESTS_INTDIR) del /f /q $(OUTDIR)\$(SIGC_TESTS_INTDIR)\*.pdb
+	@-del /f /q $(OUTDIR)\$(SIGC_EX_INTDIR)\*.obj
+	@-del /f /q $(OUTDIR)\$(SIGC_EX_INTDIR)\*.pdb
+	@-del /f /q $(OUTDIR)\$(SIGC_INTDIR)\*.res
+	@-del /f /q $(OUTDIR)\$(SIGC_INTDIR)\*.obj
+	@-del /f /q $(OUTDIR)\$(SIGC_INTDIR)\*.pdb
+	@-if exist $(OUTDIR)\$(SIGC_TESTS_INTDIR) rd $(OUTDIR)\$(SIGC_TESTS_INTDIR)
+	@-rd $(OUTDIR)\$(SIGC_EX_INTDIR)
+	@-for %d in ($(sigc_m4_srcdirs)) do @for %x in (cc h) do @if exist $(OUTDIR)\$(SIGC_INTDIR)\sigc++\%d\ del /f /q $(OUTDIR)\$(SIGC_INTDIR)\sigc++\%d\*.%x
+	@-for %x in (cc h) do @if exist $(OUTDIR)\$(SIGC_INTDIR)\sigc++\ del /f /q $(OUTDIR)\$(SIGC_INTDIR)\sigc++\*.%x
+	@-for %d in ($(sigc_m4_srcdirs)) do @rd $(OUTDIR)\$(SIGC_INTDIR)\sigc++\%d
+	@-rd $(OUTDIR)\$(SIGC_INTDIR)\sigc++
+	@-rd $(OUTDIR)\$(SIGC_INTDIR)
 
 forceclean: clean
 	@-for %d in (. adaptors\lambda adaptors functors) do @for %t in (.. ..\untracked) do @for %x in (cc h) do @for %f in (..\sigc++\%d\macros\*.%x.m4) do @del %t\sigc++\%d\%~nf

--- a/MSVC_NMake/config-msvc.mak
+++ b/MSVC_NMake/config-msvc.mak
@@ -1,19 +1,41 @@
 # NMake Makefile portion for enabling features for Windows builds
 
 # These are the base minimum libraries required for building libsigc++.
-BASE_INCLUDES =	/I$(PREFIX)\include
+!ifndef BASE_INCLUDEDIR
+BASE_INCLUDEDIR = $(PREFIX)\include
+!endif
+!ifndef BASE_LIBDIR
+BASE_LIBDIR = $(PREFIX)\lib
+!endif
 
 # Please do not change anything beneath this line unless maintaining the NMake Makefiles
 
-LIBSIGC_MAJOR_VERSION = 2
-LIBSIGC_MINOR_VERSION = 0
+SIGC_MAJOR_VERSION = 2
+SIGC_MINOR_VERSION = 0
+SIGC_SERIES = $(SIGC_MAJOR_VERSION).$(SIGC_MINOR_VERSION)
+OUTDIR=vs$(VSVER)\$(CFG)\$(PLAT)
+
+DEPS_MKFILE = deps-vs$(VSVER)-$(PLAT)-$(CFG).mak
+M4_PATH_MKFILE = find-m4-bindir-vs$(VSVER)-$(PLAT)-$(CFG).mak
+UNIX_TOOLS_PATH_MKFILE = check-unix-tools-bindir-vs$(VSVER)-$(PLAT)-$(CFG).mak
+
+# Gather up dependencies for their include directories and lib/bin dirs.
+!if [for %t in (BOOST) do @(echo !ifndef %t_INCLUDEDIR>>$(DEPS_MKFILE) & echo %t_INCLUDEDIR=^$^(BASE_INCLUDEDIR^)>>$(DEPS_MKFILE) & echo !endif>>$(DEPS_MKFILE))]
+!endif
+!if [for %t in (BOOST) do @(echo !ifndef %t_LIBDIR>>$(DEPS_MKFILE) & echo %t_LIBDIR=^$^(BASE_LIBDIR^)>>$(DEPS_MKFILE) & echo !endif>>$(DEPS_MKFILE))]
+!endif
+
+!include $(DEPS_MKFILE)
+
+!if [del /f/q $(DEPS_MKFILE)]
+!endif
 
 !ifdef STATIC
-LIBSIGC_INTDIR = sigc-static
+SIGC_INTDIR = sigc-static
 SIGC_EX_INTDIR = sigc-examples-static
 SIGC_TESTS_INTDIR = sigc-tests-static
 !else
-LIBSIGC_INTDIR = sigc
+SIGC_INTDIR = sigc
 SIGC_EX_INTDIR = sigc-examples
 SIGC_TESTS_INTDIR = sigc-tests
 !endif
@@ -25,51 +47,86 @@ DEBUG_SUFFIX =
 !endif
 
 !ifndef M4
+!ifdef UNIX_TOOLS_BINDIR
+M4 = $(UNIX_TOOLS_BINDIR)\m4.exe
+!else
 M4 = m4
 !endif
+!endif
 
-LIBSIGCPP_DEFINES = /DSIGC_BUILD
+# Try to deduce full path to m4.exe, as needed
+!if [if not exist $(M4)\ if exist $(M4) echo M4_FULL_PATH = $(M4)>$(M4_PATH_MKFILE)]
+!endif
+!if [if exist $(M4).exe echo M4_FULL_PATH = $(M4).exe>$(M4_PATH_MKFILE)]
+!endif
+!if [if not exist $(M4_PATH_MKFILE) ((echo M4_FULL_PATH = \>$(M4_PATH_MKFILE)) & where $(M4)>>$(M4_PATH_MKFILE) 2>NUL)]
+!endif
 
-SIGCPP_BASE_CFLAGS =	\
-	/Ivs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)	\
-	/I..\untracked /I.. /I..\untracked\MSVC_NMake /I.	\
-	/EHsc $(CFLAGS)
+!include $(M4_PATH_MKFILE)
+
+!if [del /f/q $(M4_PATH_MKFILE)]
+!endif
+
+!if [if not "$(UNIX_TOOLS_BINDIR)" == "" if not "$(M4_FULL_PATH)" == "" echo UNIX_TOOLS_BINDIR_CHECKED = $(UNIX_TOOLS_BINDIR)>$(UNIX_TOOLS_PATH_MKFILE)]
+!endif
+
+!if [if "$(UNIX_TOOLS_BINDIR)" == "" if not "$(M4_FULL_PATH)" == "" (for %f in ($(M4_FULL_PATH)) do @echo UNIX_TOOLS_BINDIR_CHECKED = %~dpf>$(UNIX_TOOLS_PATH_MKFILE))]
+!endif
+
+!if [if not exist $(UNIX_TOOLS_PATH_MKFILE) (echo UNIX_TOOLS_BINDIR_CHECKED = >$(UNIX_TOOLS_PATH_MKFILE))]
+!endif
+
+!include $(UNIX_TOOLS_PATH_MKFILE)
+
+!if [del /f/q $(UNIX_TOOLS_PATH_MKFILE)]
+!endif
+
+SIGC_DEFINES = /DSIGC_BUILD
+
+SIGC_INCLUDES =	\
+	/I$(OUTDIR)\$(SIGC_INTDIR)	\
+	/I..\untracked /I.. /I..\untracked\MSVC_NMake /I.
 
 # Define LIBSIGCXX_STATIC everywhere for static builds
 !ifdef STATIC
-SIGCPP_BASE_CFLAGS = $(SIGCPP_BASE_CFLAGS) /DLIBSIGCXX_STATIC
+SIGC_DEFINES = $(SIGC_DEFINES) /DLIBSIGCXX_STATIC
 !endif
+SIGC_PROGRAMS_DEFINES = $(SIGC_DEFINES:/DSIGC_BUILD=)
 
-LIBSIGC_INT_SOURCES = $(sigc_sources_cc:/=\)
-LIBSIGC_INT_HDRS = $(sigc_public_h:/=\)
+SIGC_INT_SOURCES = $(sigc_sources_cc:/=\)
+SIGC_INT_HDRS = $(sigc_public_h:/=\)
 
-SIGCPP_CFLAGS = $(SIGCPP_BASE_CFLAGS) $(CFLAGS)
-LIBSIGCPP_CFLAGS = $(SIGCPP_CFLAGS) $(LIBSIGCPP_DEFINES)
+SIGC_CXXFLAGS = $(SIGC_BASE_CFLAGS)
+SIGC_CXXFLAGS = $(SIGC_CXXFLAGS) $(SIGC_DEFINES)
 
-# We build sigc-vc$(PDBVER)0-$(LIBSIGC_MAJOR_VERSION)_$(LIBSIGC_MINOR_VERSION).dll or
-#          sigc-vc$(PDBVER)0d-$(LIBSIGC_MAJOR_VERSION)_$(LIBSIGC_MINOR_VERSION).dll at least
+# We build sigc-vc$(PDBVER)0-$(SIGC_MAJOR_VERSION)_$(SIGC_MINOR_VERSION).dll or
+#          sigc-vc$(PDBVER)0d-$(SIGC_MAJOR_VERSION)_$(SIGC_MINOR_VERSION).dll at least
 
 !ifdef USE_MESON_LIBS
-LIBSIGC_LIBNAME = sigc-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)
-LIBSIGC_DLLNAME = $(LIBSIGC_LIBNAME)-0
+SIGC_LIBNAME = sigc-$(SIGC_SERIES)
+SIGC_DLLNAME = $(SIGC_LIBNAME)-0
 !else
-LIBSIGC_LIBNAME = sigc-vc$(PDBVER)0$(DEBUG_SUFFIX)-$(LIBSIGC_MAJOR_VERSION)_$(LIBSIGC_MINOR_VERSION)
-LIBSIGC_DLLNAME = $(LIBSIGC_LIBNAME)
+SIGC_LIBNAME = sigc-vc$(PDBVER)0$(DEBUG_SUFFIX)-$(SIGC_SERIES:.=_)
+SIGC_DLLNAME = $(SIGC_LIBNAME)
 !endif
 
 !ifdef STATIC
-LIBSIGC_LIB = vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME)-static.lib
+SIGC_LIB = $(OUTDIR)\$(SIGC_LIBNAME)-static.lib
 !else
-LIBSIGC_DLL = vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_DLLNAME).dll
-LIBSIGC_LIB = vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_LIBNAME).lib
+SIGC_DLL = $(OUTDIR)\$(SIGC_DLLNAME).dll
+SIGC_LIB = $(OUTDIR)\$(SIGC_LIBNAME).lib
 !endif
 
 # Note that building the benchmark requires Boost!
-libsigc_bench = vs$(VSVER)\$(CFG)\$(PLAT)\libsigc++-benchmark.exe
+libsigc_bench = $(OUTDIR)\libsigc++-benchmark.exe
 
 # If your Boost libraries are built as DLLs, use BOOST_DLL=1 in your NMake command line
+SIGC_BENCHMARK_INCLUDES = /I$(BOOST_INCLUDEDIR)
+SIGC_BENCHMARK_LDFLAGS = /libpath:$(BASE_LIBDIR)
+!if "$(BOOST_LIBDIR)" != ""
+SIGC_BENCHMARK_LDFLAGS = /libpath:$(BOOST_LIBDIR)
+!endif
+SIGC_BENCHMARK_CFLAGS = $(SIGC_PROGRAMS_DEFINES)
 !ifdef BOOST_DLL
-SIGCPP_BENCHMARK_CFLAGS = $(SIGCPP_BASE_CFLAGS) /DBOOST_ALL_DYN_LINK
-!else
-SIGCPP_BENCHMARK_CFLAGS = $(SIGCPP_BASE_CFLAGS)
+SIGC_BENCHMARK_CFLAGS = $(SIGC_BENCHMARK_CFLAGS) /DBOOST_ALL_DYN_LINK
 !endif

--- a/MSVC_NMake/config-msvc.mak
+++ b/MSVC_NMake/config-msvc.mak
@@ -18,6 +18,7 @@ OUTDIR=vs$(VSVER)\$(CFG)\$(PLAT)
 DEPS_MKFILE = deps-vs$(VSVER)-$(PLAT)-$(CFG).mak
 M4_PATH_MKFILE = find-m4-bindir-vs$(VSVER)-$(PLAT)-$(CFG).mak
 UNIX_TOOLS_PATH_MKFILE = check-unix-tools-bindir-vs$(VSVER)-$(PLAT)-$(CFG).mak
+BUILD_MKFILE_SNIPPET = sigc-vs$(VSVER)-$(PLAT)-$(CFG).mak
 
 # Gather up dependencies for their include directories and lib/bin dirs.
 !if [for %t in (BOOST) do @(echo !ifndef %t_INCLUDEDIR>>$(DEPS_MKFILE) & echo %t_INCLUDEDIR=^$^(BASE_INCLUDEDIR^)>>$(DEPS_MKFILE) & echo !endif>>$(DEPS_MKFILE))]

--- a/MSVC_NMake/create-lists-msvc.mak
+++ b/MSVC_NMake/create-lists-msvc.mak
@@ -38,12 +38,12 @@ NULL=
 !if [call create-lists.bat header sigc.mak libsigc_OBJS]
 !endif
 
-!if [for %c in ($(sigc_sources_cc)) do @if "%~xc" == ".cc" @call create-lists.bat file sigc.mak vs^$(VSVER)\^$(CFG)\^$(PLAT)\$(LIBSIGC_INTDIR)\%~nc.obj]
+!if [for %c in ($(sigc_sources_cc)) do @if "%~xc" == ".cc" @call create-lists.bat file sigc.mak ^$(OUTDIR)\^$(SIGC_INTDIR)\%~nc.obj]
 !endif
 
 # No point linking in version resource for static builds
 !ifndef STATIC
-!if [@call create-lists.bat file sigc.mak vs^$(VSVER)\^$(CFG)\^$(PLAT)\$(LIBSIGC_INTDIR)\sigc.res]
+!if [@call create-lists.bat file sigc.mak ^$(OUTDIR)\^$(SIGC_INTDIR)\sigc.res]
 !endif
 !endif
 
@@ -61,42 +61,48 @@ NULL=
 
 !ifdef STATIC
 # start of static executables
-!if [for %d in (examples tests) do @call create-lists.bat header sigc.mak libsigc_%d & @(for %s in (..\%d\*.cc) do @if not "%~ns" == "testutilities" if not "%~ns" == "benchmark" call create-lists.bat file sigc.mak vs$(VSVER)\$(CFG)\$(PLAT)\%~ns-static.exe) & @call create-lists.bat footer sigc.mak]
+!if [for %d in (examples tests) do @call create-lists.bat header sigc.mak libsigc_%d & @(for %s in (..\%d\*.cc) do @if not "%~ns" == "testutilities" if not "%~ns" == "benchmark" call create-lists.bat file sigc.mak $(OUTDIR)\%~ns-static.exe) & @call create-lists.bat footer sigc.mak]
 !endif
 
-!if [call create-lists.bat header sigc.mak libsigc_benchmark & @for %s in (..\tests\benchmark.cc) do @(call create-lists.bat file sigc.mak vs$(VSVER)\$(CFG)\$(PLAT)\%~ns-static.exe) & @call create-lists.bat footer sigc.mak]
+!if [call create-lists.bat header sigc.mak libsigc_benchmark & @for %s in (..\tests\benchmark.cc) do @(call create-lists.bat file sigc.mak $(OUTDIR)\%~ns-static.exe) & @call create-lists.bat footer sigc.mak]
 !endif
 
-!if [for %d in (examples tests) do @for %s in (..\%d\*.cc) do @if not "%~ns" == "benchmark" echo vs^$(VSVER)\^$(CFG)\^$(PLAT)\sigc-%d-static\%~ns.obj: %s>>sigc.mak & @echo. @if not exist ^$(@D)\ md ^$(@D)>>sigc.mak & @echo. ^$(CXX) ^$(SIGCPP_CFLAGS) /Fo^$(@D)\ /Fd^$(@D)\ ^$** /c>>sigc.mak & @echo.>>sigc.mak]
+!if [for %d in (examples tests) do @for %s in (..\%d\*.cc) do @if not "%~ns" == "benchmark" echo ^$(OUTDIR)\sigc-%d-static\%~ns.obj: %s>>sigc.mak & @echo. @if not exist ^$(@D)\ md ^$(@D)>>sigc.mak & @echo. ^$(CXX) ^$(CFLAGS) ^$(SIGC_PROGRAMS_DEFINES) ^$(SIGC_INCLUDES) /Fo^$(@D)\ /Fd^$(@D)\ ^$** /c>>sigc.mak & @echo.>>sigc.mak]
 !endif
 
-!if [for %s in (..\examples\*.cc) do @echo vs^$(VSVER)\^$(CFG)\^$(PLAT)\%~ns-static.exe: ^$(LIBSIGC_LIB) vs^$(VSVER)\^$(CFG)\^$(PLAT)\$(SIGC_EX_INTDIR)\%~ns.obj>>sigc.mak & @echo. link ^$(LDFLAGS) ^$** /out:^$@>>sigc.mak & @echo.>>sigc.mak]
+!if [for %s in (..\examples\*.cc) do @echo ^$(OUTDIR)\%~ns-static.exe: ^$(SIGC_LIB) ^$(OUTDIR)\$(SIGC_EX_INTDIR)\%~ns.obj>>sigc.mak & @echo. link ^$(LDFLAGS) ^$** /out:^$@>>sigc.mak & @echo.>>sigc.mak]
 !endif
 
-!if [for %s in (..\tests\*.cc) do @if not "%~ns" == "testutilities" echo vs^$(VSVER)\^$(CFG)\^$(PLAT)\%~ns-static.exe: ^$(LIBSIGC_LIB) vs^$(VSVER)\^$(CFG)\^$(PLAT)\$(SIGC_TESTS_INTDIR)\%~ns.obj vs^$(VSVER)\^$(CFG)\^$(PLAT)\$(SIGC_TESTS_INTDIR)\testutilities.obj>>sigc.mak & @echo. link ^$(LDFLAGS) ^$** /out:^$@>>sigc.mak & @echo.>>sigc.mak]
+!if [for %s in (..\tests\*.cc) do @if not "%~ns" == "testutilities" echo ^$(OUTDIR)\%~ns-static.exe: ^$(SIGC_LIB) ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\%~ns.obj ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\testutilities.obj>>sigc.mak & @echo. link ^$(LDFLAGS) ^$** /out:^$@>>sigc.mak & @echo.>>sigc.mak]
+!endif
+
+!if [for %s in (..\tests\benchmark.cc) do @echo ^$(OUTDIR)\%~ns-static.exe: ^$(SIGC_LIB) ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\%~ns.obj ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\testutilities.obj>>sigc.mak & @echo. link ^$(LDFLAGS) ^$(SIGC_BENCHMARK_LDFLAGS) ^$** /out:^$@>>sigc.mak & @echo.>>sigc.mak]
 !endif
 # end of static executables
 !else
 # start of shared executables
-!if [for %d in (examples tests) do @call create-lists.bat header sigc.mak libsigc_%d & @(for %s in (..\%d\*.cc) do @if not "%~ns" == "testutilities" if not "%~ns" == "benchmark" call create-lists.bat file sigc.mak vs$(VSVER)\$(CFG)\$(PLAT)\%~ns.exe) & @call create-lists.bat footer sigc.mak]
+!if [for %d in (examples tests) do @call create-lists.bat header sigc.mak libsigc_%d & @(for %s in (..\%d\*.cc) do @if not "%~ns" == "testutilities" if not "%~ns" == "benchmark" call create-lists.bat file sigc.mak $(OUTDIR)\%~ns.exe) & @call create-lists.bat footer sigc.mak]
 !endif
 
-!if [call create-lists.bat header sigc.mak libsigc_benchmark & @for %s in (..\tests\benchmark.cc) do @(call create-lists.bat file sigc.mak vs$(VSVER)\$(CFG)\$(PLAT)\%~ns.exe) & @call create-lists.bat footer sigc.mak]
+!if [call create-lists.bat header sigc.mak libsigc_benchmark & @for %s in (..\tests\benchmark.cc) do @(call create-lists.bat file sigc.mak $(OUTDIR)\%~ns.exe) & @call create-lists.bat footer sigc.mak]
 !endif
 
-!if [for %d in (examples tests) do @for %s in (..\%d\*.cc) do @if not "%~ns" == "benchmark" echo vs^$(VSVER)\^$(CFG)\^$(PLAT)\sigc-%d\%~ns.obj: %s>>sigc.mak & @echo. @if not exist ^$(@D)\ md ^$(@D)>>sigc.mak & @echo. ^$(CXX) ^$(SIGCPP_CFLAGS) /Fo^$(@D)\ /Fd^$(@D)\ ^$** /c>>sigc.mak & @echo.>>sigc.mak]
+!if [for %d in (examples tests) do @for %s in (..\%d\*.cc) do @if not "%~ns" == "benchmark" echo ^$(OUTDIR)\sigc-%d\%~ns.obj: %s>>sigc.mak & @echo. @if not exist ^$(@D)\ md ^$(@D)>>sigc.mak & @echo. ^$(CXX) ^$(CFLAGS) ^$(SIGC_PROGRAMS_DEFINES) ^$(SIGC_INCLUDES) /Fo^$(@D)\ /Fd^$(@D)\ ^$** /c>>sigc.mak & @echo.>>sigc.mak]
 !endif
 
-!if [for %s in (..\examples\*.cc) do @echo vs^$(VSVER)\^$(CFG)\^$(PLAT)\%~ns.exe: ^$(LIBSIGC_LIB) vs^$(VSVER)\^$(CFG)\^$(PLAT)\$(SIGC_EX_INTDIR)\%~ns.obj>>sigc.mak & @echo. link ^$(LDFLAGS) ^$** /out:^$@>>sigc.mak & @echo.>>sigc.mak]
+!if [for %s in (..\examples\*.cc) do @echo ^$(OUTDIR)\%~ns.exe: ^$(SIGC_LIB) ^$(OUTDIR)\$(SIGC_EX_INTDIR)\%~ns.obj>>sigc.mak & @echo. link ^$(LDFLAGS) ^$** /out:^$@>>sigc.mak & @echo.>>sigc.mak]
 !endif
 
-!if [for %s in (..\tests\*.cc) do @if not "%~ns" == "testutilities" echo vs^$(VSVER)\^$(CFG)\^$(PLAT)\%~ns.exe: ^$(LIBSIGC_LIB) vs^$(VSVER)\^$(CFG)\^$(PLAT)\$(SIGC_TESTS_INTDIR)\%~ns.obj vs^$(VSVER)\^$(CFG)\^$(PLAT)\$(SIGC_TESTS_INTDIR)\testutilities.obj>>sigc.mak & @echo. link ^$(LDFLAGS) ^$** /out:^$@>>sigc.mak & @echo.>>sigc.mak]
+!if [for %s in (..\tests\*.cc) do @if not "%~ns" == "testutilities" if not "%~ns" == "benchmark" echo ^$(OUTDIR)\%~ns.exe: ^$(SIGC_LIB) ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\%~ns.obj ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\testutilities.obj>>sigc.mak & @echo. link ^$(LDFLAGS) ^$** /out:^$@>>sigc.mak & @echo.>>sigc.mak]
+!endif
+
+!if [for %s in (..\tests\benchmark.cc) do @echo ^$(OUTDIR)\%~ns.exe: ^$(SIGC_LIB) ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\%~ns.obj ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\testutilities.obj>>sigc.mak & @echo. link ^$(LDFLAGS) ^$(SIGC_BENCHMARK_LDFLAGS) ^$** /out:^$@>>sigc.mak & @echo.>>sigc.mak]
 !endif
 
 # end of shared executables
 !endif
 
-!if [for %s in (..\tests\benchmark.cc) do @echo vs^$(VSVER)\^$(CFG)\^$(PLAT)\$(SIGC_TESTS_INTDIR)\%~ns.obj: %s>>sigc.mak & @echo. @if not exist ^$(@D)\ md ^$(@D)>>sigc.mak & @echo. ^$(CXX) ^$(SIGCPP_BENCHMARK_CFLAGS) /Fo^$(@D)\ /Fd^$(@D)\ ^$** /c>>sigc.mak & @echo.>>sigc.mak]
+!if [for %s in (..\tests\benchmark.cc) do @echo ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\%~ns.obj: %s>>sigc.mak & @echo. @if not exist ^$(@D)\ md ^$(@D)>>sigc.mak & @echo. ^$(CXX) ^$(CFLAGS) ^$(SIGC_BENCHMARK_CFLAGS) ^$(SIGC_BENCHMARK_INCLUDES) ^$(SIGC_INCLUDES) /Fo^$(@D)\ /Fd^$(@D)\ ^$** /c>>sigc.mak & @echo.>>sigc.mak]
 !endif
 
 !include sigc.mak

--- a/MSVC_NMake/create-lists-msvc.mak
+++ b/MSVC_NMake/create-lists-msvc.mak
@@ -35,77 +35,77 @@ NULL=
 
 # For libsigc++
 
-!if [call create-lists.bat header sigc.mak libsigc_OBJS]
+!if [call create-lists.bat header $(BUILD_MKFILE_SNIPPET) libsigc_OBJS]
 !endif
 
-!if [for %c in ($(sigc_sources_cc)) do @if "%~xc" == ".cc" @call create-lists.bat file sigc.mak ^$(OUTDIR)\^$(SIGC_INTDIR)\%~nc.obj]
+!if [for %c in ($(sigc_sources_cc)) do @if "%~xc" == ".cc" @call create-lists.bat file $(BUILD_MKFILE_SNIPPET) ^$(OUTDIR)\^$(SIGC_INTDIR)\%~nc.obj]
 !endif
 
 # No point linking in version resource for static builds
 !ifndef STATIC
-!if [@call create-lists.bat file sigc.mak ^$(OUTDIR)\^$(SIGC_INTDIR)\sigc.res]
+!if [@call create-lists.bat file $(BUILD_MKFILE_SNIPPET) ^$(OUTDIR)\^$(SIGC_INTDIR)\sigc.res]
 !endif
 !endif
 
-!if [call create-lists.bat footer sigc.mak]
+!if [call create-lists.bat footer $(BUILD_MKFILE_SNIPPET)]
 !endif
 
-!if [call create-lists.bat header sigc.mak sigc_m4_srcdirs]
+!if [call create-lists.bat header $(BUILD_MKFILE_SNIPPET) sigc_m4_srcdirs]
 !endif
 
-!if [for %d in (adaptors\lambda adaptors functors) do @call create-lists.bat file sigc.mak %d]
+!if [for %d in (adaptors\lambda adaptors functors) do @call create-lists.bat file $(BUILD_MKFILE_SNIPPET) %d]
 !endif
 
-!if [call create-lists.bat footer sigc.mak]
+!if [call create-lists.bat footer $(BUILD_MKFILE_SNIPPET)]
 !endif
 
 !ifdef STATIC
 # start of static executables
-!if [for %d in (examples tests) do @call create-lists.bat header sigc.mak libsigc_%d & @(for %s in (..\%d\*.cc) do @if not "%~ns" == "testutilities" if not "%~ns" == "benchmark" call create-lists.bat file sigc.mak $(OUTDIR)\%~ns-static.exe) & @call create-lists.bat footer sigc.mak]
+!if [for %d in (examples tests) do @call create-lists.bat header $(BUILD_MKFILE_SNIPPET) libsigc_%d & @(for %s in (..\%d\*.cc) do @if not "%~ns" == "testutilities" if not "%~ns" == "benchmark" call create-lists.bat file $(BUILD_MKFILE_SNIPPET) $(OUTDIR)\%~ns-static.exe) & @call create-lists.bat footer $(BUILD_MKFILE_SNIPPET)]
 !endif
 
-!if [call create-lists.bat header sigc.mak libsigc_benchmark & @for %s in (..\tests\benchmark.cc) do @(call create-lists.bat file sigc.mak $(OUTDIR)\%~ns-static.exe) & @call create-lists.bat footer sigc.mak]
+!if [call create-lists.bat header $(BUILD_MKFILE_SNIPPET) libsigc_benchmark & @for %s in (..\tests\benchmark.cc) do @(call create-lists.bat file $(BUILD_MKFILE_SNIPPET) $(OUTDIR)\%~ns-static.exe) & @call create-lists.bat footer $(BUILD_MKFILE_SNIPPET)]
 !endif
 
-!if [for %d in (examples tests) do @for %s in (..\%d\*.cc) do @if not "%~ns" == "benchmark" echo ^$(OUTDIR)\sigc-%d-static\%~ns.obj: %s>>sigc.mak & @echo. @if not exist ^$(@D)\ md ^$(@D)>>sigc.mak & @echo. ^$(CXX) ^$(CFLAGS) ^$(SIGC_PROGRAMS_DEFINES) ^$(SIGC_INCLUDES) /Fo^$(@D)\ /Fd^$(@D)\ ^$** /c>>sigc.mak & @echo.>>sigc.mak]
+!if [for %d in (examples tests) do @for %s in (..\%d\*.cc) do @if not "%~ns" == "benchmark" echo ^$(OUTDIR)\sigc-%d-static\%~ns.obj: %s>>$(BUILD_MKFILE_SNIPPET) & @echo. @if not exist ^$(@D)\ md ^$(@D)>>$(BUILD_MKFILE_SNIPPET) & @echo. ^$(CXX) ^$(CFLAGS) ^$(SIGC_PROGRAMS_DEFINES) ^$(SIGC_INCLUDES) /Fo^$(@D)\ /Fd^$(@D)\ ^$** /c>>$(BUILD_MKFILE_SNIPPET) & @echo.>>$(BUILD_MKFILE_SNIPPET)]
 !endif
 
-!if [for %s in (..\examples\*.cc) do @echo ^$(OUTDIR)\%~ns-static.exe: ^$(SIGC_LIB) ^$(OUTDIR)\$(SIGC_EX_INTDIR)\%~ns.obj>>sigc.mak & @echo. link ^$(LDFLAGS) ^$** /out:^$@>>sigc.mak & @echo.>>sigc.mak]
+!if [for %s in (..\examples\*.cc) do @echo ^$(OUTDIR)\%~ns-static.exe: ^$(SIGC_LIB) ^$(OUTDIR)\$(SIGC_EX_INTDIR)\%~ns.obj>>$(BUILD_MKFILE_SNIPPET) & @echo. link ^$(LDFLAGS) ^$** /out:^$@>>$(BUILD_MKFILE_SNIPPET) & @echo.>>$(BUILD_MKFILE_SNIPPET)]
 !endif
 
-!if [for %s in (..\tests\*.cc) do @if not "%~ns" == "testutilities" echo ^$(OUTDIR)\%~ns-static.exe: ^$(SIGC_LIB) ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\%~ns.obj ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\testutilities.obj>>sigc.mak & @echo. link ^$(LDFLAGS) ^$** /out:^$@>>sigc.mak & @echo.>>sigc.mak]
+!if [for %s in (..\tests\*.cc) do @if not "%~ns" == "testutilities" echo ^$(OUTDIR)\%~ns-static.exe: ^$(SIGC_LIB) ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\%~ns.obj ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\testutilities.obj>>$(BUILD_MKFILE_SNIPPET) & @echo. link ^$(LDFLAGS) ^$** /out:^$@>>$(BUILD_MKFILE_SNIPPET) & @echo.>>$(BUILD_MKFILE_SNIPPET)]
 !endif
 
-!if [for %s in (..\tests\benchmark.cc) do @echo ^$(OUTDIR)\%~ns-static.exe: ^$(SIGC_LIB) ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\%~ns.obj ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\testutilities.obj>>sigc.mak & @echo. link ^$(LDFLAGS) ^$(SIGC_BENCHMARK_LDFLAGS) ^$** /out:^$@>>sigc.mak & @echo.>>sigc.mak]
+!if [for %s in (..\tests\benchmark.cc) do @echo ^$(OUTDIR)\%~ns-static.exe: ^$(SIGC_LIB) ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\%~ns.obj ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\testutilities.obj>>$(BUILD_MKFILE_SNIPPET) & @echo. link ^$(LDFLAGS) ^$(SIGC_BENCHMARK_LDFLAGS) ^$** /out:^$@>>$(BUILD_MKFILE_SNIPPET) & @echo.>>$(BUILD_MKFILE_SNIPPET)]
 !endif
 # end of static executables
 !else
 # start of shared executables
-!if [for %d in (examples tests) do @call create-lists.bat header sigc.mak libsigc_%d & @(for %s in (..\%d\*.cc) do @if not "%~ns" == "testutilities" if not "%~ns" == "benchmark" call create-lists.bat file sigc.mak $(OUTDIR)\%~ns.exe) & @call create-lists.bat footer sigc.mak]
+!if [for %d in (examples tests) do @call create-lists.bat header $(BUILD_MKFILE_SNIPPET) libsigc_%d & @(for %s in (..\%d\*.cc) do @if not "%~ns" == "testutilities" if not "%~ns" == "benchmark" call create-lists.bat file $(BUILD_MKFILE_SNIPPET) $(OUTDIR)\%~ns.exe) & @call create-lists.bat footer $(BUILD_MKFILE_SNIPPET)]
 !endif
 
-!if [call create-lists.bat header sigc.mak libsigc_benchmark & @for %s in (..\tests\benchmark.cc) do @(call create-lists.bat file sigc.mak $(OUTDIR)\%~ns.exe) & @call create-lists.bat footer sigc.mak]
+!if [call create-lists.bat header $(BUILD_MKFILE_SNIPPET) libsigc_benchmark & @for %s in (..\tests\benchmark.cc) do @(call create-lists.bat file $(BUILD_MKFILE_SNIPPET) $(OUTDIR)\%~ns.exe) & @call create-lists.bat footer $(BUILD_MKFILE_SNIPPET)]
 !endif
 
-!if [for %d in (examples tests) do @for %s in (..\%d\*.cc) do @if not "%~ns" == "benchmark" echo ^$(OUTDIR)\sigc-%d\%~ns.obj: %s>>sigc.mak & @echo. @if not exist ^$(@D)\ md ^$(@D)>>sigc.mak & @echo. ^$(CXX) ^$(CFLAGS) ^$(SIGC_PROGRAMS_DEFINES) ^$(SIGC_INCLUDES) /Fo^$(@D)\ /Fd^$(@D)\ ^$** /c>>sigc.mak & @echo.>>sigc.mak]
+!if [for %d in (examples tests) do @for %s in (..\%d\*.cc) do @if not "%~ns" == "benchmark" echo ^$(OUTDIR)\sigc-%d\%~ns.obj: %s>>$(BUILD_MKFILE_SNIPPET) & @echo. @if not exist ^$(@D)\ md ^$(@D)>>$(BUILD_MKFILE_SNIPPET) & @echo. ^$(CXX) ^$(CFLAGS) ^$(SIGC_PROGRAMS_DEFINES) ^$(SIGC_INCLUDES) /Fo^$(@D)\ /Fd^$(@D)\ ^$** /c>>$(BUILD_MKFILE_SNIPPET) & @echo.>>$(BUILD_MKFILE_SNIPPET)]
 !endif
 
-!if [for %s in (..\examples\*.cc) do @echo ^$(OUTDIR)\%~ns.exe: ^$(SIGC_LIB) ^$(OUTDIR)\$(SIGC_EX_INTDIR)\%~ns.obj>>sigc.mak & @echo. link ^$(LDFLAGS) ^$** /out:^$@>>sigc.mak & @echo.>>sigc.mak]
+!if [for %s in (..\examples\*.cc) do @echo ^$(OUTDIR)\%~ns.exe: ^$(SIGC_LIB) ^$(OUTDIR)\$(SIGC_EX_INTDIR)\%~ns.obj>>$(BUILD_MKFILE_SNIPPET) & @echo. link ^$(LDFLAGS) ^$** /out:^$@>>$(BUILD_MKFILE_SNIPPET) & @echo.>>$(BUILD_MKFILE_SNIPPET)]
 !endif
 
-!if [for %s in (..\tests\*.cc) do @if not "%~ns" == "testutilities" if not "%~ns" == "benchmark" echo ^$(OUTDIR)\%~ns.exe: ^$(SIGC_LIB) ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\%~ns.obj ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\testutilities.obj>>sigc.mak & @echo. link ^$(LDFLAGS) ^$** /out:^$@>>sigc.mak & @echo.>>sigc.mak]
+!if [for %s in (..\tests\*.cc) do @if not "%~ns" == "testutilities" if not "%~ns" == "benchmark" echo ^$(OUTDIR)\%~ns.exe: ^$(SIGC_LIB) ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\%~ns.obj ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\testutilities.obj>>$(BUILD_MKFILE_SNIPPET) & @echo. link ^$(LDFLAGS) ^$** /out:^$@>>$(BUILD_MKFILE_SNIPPET) & @echo.>>$(BUILD_MKFILE_SNIPPET)]
 !endif
 
-!if [for %s in (..\tests\benchmark.cc) do @echo ^$(OUTDIR)\%~ns.exe: ^$(SIGC_LIB) ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\%~ns.obj ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\testutilities.obj>>sigc.mak & @echo. link ^$(LDFLAGS) ^$(SIGC_BENCHMARK_LDFLAGS) ^$** /out:^$@>>sigc.mak & @echo.>>sigc.mak]
+!if [for %s in (..\tests\benchmark.cc) do @echo ^$(OUTDIR)\%~ns.exe: ^$(SIGC_LIB) ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\%~ns.obj ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\testutilities.obj>>$(BUILD_MKFILE_SNIPPET) & @echo. link ^$(LDFLAGS) ^$(SIGC_BENCHMARK_LDFLAGS) ^$** /out:^$@>>$(BUILD_MKFILE_SNIPPET) & @echo.>>$(BUILD_MKFILE_SNIPPET)]
 !endif
 
 # end of shared executables
 !endif
 
-!if [for %s in (..\tests\benchmark.cc) do @echo ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\%~ns.obj: %s>>sigc.mak & @echo. @if not exist ^$(@D)\ md ^$(@D)>>sigc.mak & @echo. ^$(CXX) ^$(CFLAGS) ^$(SIGC_BENCHMARK_CFLAGS) ^$(SIGC_BENCHMARK_INCLUDES) ^$(SIGC_INCLUDES) /Fo^$(@D)\ /Fd^$(@D)\ ^$** /c>>sigc.mak & @echo.>>sigc.mak]
+!if [for %s in (..\tests\benchmark.cc) do @echo ^$(OUTDIR)\$(SIGC_TESTS_INTDIR)\%~ns.obj: %s>>$(BUILD_MKFILE_SNIPPET) & @echo. @if not exist ^$(@D)\ md ^$(@D)>>$(BUILD_MKFILE_SNIPPET) & @echo. ^$(CXX) ^$(CFLAGS) ^$(SIGC_BENCHMARK_CFLAGS) ^$(SIGC_BENCHMARK_INCLUDES) ^$(SIGC_INCLUDES) /Fo^$(@D)\ /Fd^$(@D)\ ^$** /c>>$(BUILD_MKFILE_SNIPPET) & @echo.>>$(BUILD_MKFILE_SNIPPET)]
 !endif
 
-!include sigc.mak
+!include $(BUILD_MKFILE_SNIPPET)
 
-!if [del /f /q sigc.mak]
+!if [del /f /q $(BUILD_MKFILE_SNIPPET)]
 !endif

--- a/MSVC_NMake/detectenv-msvc.mak
+++ b/MSVC_NMake/detectenv-msvc.mak
@@ -111,13 +111,11 @@ VALID_CFGSET = TRUE
 
 # One may change these items, but be sure to test
 # the resulting binaries
+CFLAGS_BASE = /EHsc
 !if "$(CFG)" == "release" || "$(CFG)" == "Release"
-CFLAGS_ADD = /MD /O2 /GL /MP
-!if "$(VSVER)" != "9"
-CFLAGS_ADD = $(CFLAGS_ADD) /d2Zi+
-!endif
+CFLAGS_ADD = $(CFLAGS_BASE) /MD /O2 /GL /MP
 !else
-CFLAGS_ADD = /MDd /Od
+CFLAGS_ADD = $(CFLAGS_BASE) /MDd /Od
 !endif
 
 !if "$(PLAT)" == "x64"

--- a/MSVC_NMake/generate-msvc.mak
+++ b/MSVC_NMake/generate-msvc.mak
@@ -16,7 +16,7 @@ sigc.rc: ..\configure.ac sigc.rc.in
 	@if "$(DO_REAL_GEN)" == "1" $(PERL) -pi.bak -e "s/\@SIGCXX_MINOR_VERSION\@/$(PKG_MINOR_VERSION)/g" $@
 	@if "$(DO_REAL_GEN)" == "1" $(PERL) -pi.bak -e "s/\@SIGCXX_MICRO_VERSION\@/$(PKG_MICRO_VERSION)/g" $@
 	@if "$(DO_REAL_GEN)" == "1" $(PERL) -pi.bak -e "s/\@PACKAGE_VERSION\@/$(PKG_MAJOR_VERSION).$(PKG_MINOR_VERSION).$(PKG_MICRO_VERSION)/g" $@
-	@if "$(DO_REAL_GEN)" == "1" $(PERL) -pi.bak -e "s/\@SIGCXX_API_VERSION\@/$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)/g" $@
+	@if "$(DO_REAL_GEN)" == "1" $(PERL) -pi.bak -e "s/\@SIGCXX_API_VERSION\@/$(SIGC_SERIES)/g" $@
 	@if "$(DO_REAL_GEN)" == "1" del $@.bak
 
 # You may change SIGCXX_DISABLE_DEPRECATED if you know what you are doing
@@ -46,8 +46,10 @@ pkg-ver.mak: ..\configure.ac
 	$(MAKE) /f Makefile.vc CFG=$(CFG) GENERATE_VERSIONED_FILES=1 sigc.rc sigc++config.h
 
 generate-sources:
-	@for %f in ($(base_built_cc) $(base_built_h)) do @if not exist ..\sigc++\%f if not exist ..\untracked\sigc++\%f if not exist vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\sigc++\ md vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\sigc++
-	@for %d in ($(sigc_m4_srcdirs)) do @for %x in (cc h) do @for %f in (..\sigc++\%d\macros\*.%x.m4) do @if not exist ..\sigc++\%d\%~nf if not exist ..\untracked\sigc++\%d\%~nf if not exist vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\sigc++\%d\ md vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\sigc++\%d
-	@for %f in ($(base_built_cc) $(base_built_h)) do @if not exist ..\sigc++\%f if not exist ..\untracked\sigc++\%f if not exist vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\sigc++\%f @echo Generating vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\sigc++\%f... & $(M4) -I ../sigc++/macros ../sigc++/macros/%f.m4 >vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\sigc++\%f
-	@for %d in ($(sigc_m4_srcdirs:adaptors\lambda=)) do @for %x in (cc h) do @for %f in (..\sigc++\%d\macros\*.%x.m4) do @if not exist ..\sigc++\%d\%~nf if not exist ..\untracked\sigc++\%d\%~nf if not exist vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\sigc++\%d\%~nf @echo Generating vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\sigc++\%d\%~nf... & $(M4) -I ../sigc++/%d/macros -I ../sigc++/macros ../sigc++/%d/macros/%~nxf >vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\sigc++\%d\%~nf
-	@for %x in (cc h) do @for %f in (..\sigc++\adaptors\lambda\macros\*.%x.m4) do @if not exist ..\sigc++\adaptors\lambda\%~nf if not exist ..\untracked\sigc++\adaptors\lambda\%~nf if not exist vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\sigc++\adaptors\lambda\%~nf @echo Generating vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\sigc++\adaptors\lambda\%~nf... & $(M4) -I ../sigc++/adaptors/lambda/macros -I ../sigc++/macros ../sigc++/adaptors/lambda/macros/%~nxf >vs$(VSVER)\$(CFG)\$(PLAT)\$(LIBSIGC_INTDIR)\sigc++\adaptors\lambda\%~nf
+	@if "$(UNIX_TOOLS_BINDIR_CHECKED)" == "" echo Warning: m4 is not in %PATH% or specified M4 or UNIX_TOOLS_BINDIR is not valid. Builds may fail!
+	@set PATH=$(PATH);$(UNIX_TOOLS_BINDIR_CHECKED)
+	@for %f in ($(base_built_cc) $(base_built_h)) do @if not exist ..\sigc++\%f if not exist ..\untracked\sigc++\%f if not exist $(OUTDIR)\$(SIGC_INTDIR)\sigc++\ md $(OUTDIR)\$(SIGC_INTDIR)\sigc++
+	@for %d in ($(sigc_m4_srcdirs)) do @for %x in (cc h) do @for %f in (..\sigc++\%d\macros\*.%x.m4) do @if not exist ..\sigc++\%d\%~nf if not exist ..\untracked\sigc++\%d\%~nf if not exist $(OUTDIR)\$(SIGC_INTDIR)\sigc++\%d\ md $(OUTDIR)\$(SIGC_INTDIR)\sigc++\%d
+	@for %f in ($(base_built_cc) $(base_built_h)) do @if not exist ..\sigc++\%f if not exist ..\untracked\sigc++\%f if not exist $(OUTDIR)\$(SIGC_INTDIR)\sigc++\%f @echo Generating $(OUTDIR)\$(SIGC_INTDIR)\sigc++\%f... & $(M4_FULL_PATH) -I ../sigc++/macros ../sigc++/macros/%f.m4 >$(OUTDIR)\$(SIGC_INTDIR)\sigc++\%f
+	@for %d in ($(sigc_m4_srcdirs:adaptors\lambda=)) do @for %x in (cc h) do @for %f in (..\sigc++\%d\macros\*.%x.m4) do @if not exist ..\sigc++\%d\%~nf if not exist ..\untracked\sigc++\%d\%~nf if not exist $(OUTDIR)\$(SIGC_INTDIR)\sigc++\%d\%~nf @echo Generating $(OUTDIR)\$(SIGC_INTDIR)\sigc++\%d\%~nf... & $(M4_FULL_PATH) -I ../sigc++/%d/macros -I ../sigc++/macros ../sigc++/%d/macros/%~nxf >$(OUTDIR)\$(SIGC_INTDIR)\sigc++\%d\%~nf
+	@for %x in (cc h) do @for %f in (..\sigc++\adaptors\lambda\macros\*.%x.m4) do @if not exist ..\sigc++\adaptors\lambda\%~nf if not exist ..\untracked\sigc++\adaptors\lambda\%~nf if not exist $(OUTDIR)\$(SIGC_INTDIR)\sigc++\adaptors\lambda\%~nf @echo Generating $(OUTDIR)\$(SIGC_INTDIR)\sigc++\adaptors\lambda\%~nf... & $(M4_FULL_PATH) -I ../sigc++/adaptors/lambda/macros -I ../sigc++/macros ../sigc++/adaptors/lambda/macros/%~nxf >$(OUTDIR)\$(SIGC_INTDIR)\sigc++\adaptors\lambda\%~nf

--- a/MSVC_NMake/info-msvc.mak
+++ b/MSVC_NMake/info-msvc.mak
@@ -22,20 +22,45 @@ help:
 	@echo for a debug build.  PDB files are generated for all builds.
 	@echo.
 	@echo PREFIX: Optional, the path where dependent libraries and tools may be
-	@echo found, default is ^$(srcrootdir)\..\vs^$(short_vs_ver)\^$(platform),
-	@echo where ^$(short_vs_ver) is 12 for VS 2013 and 14 for VS 2015 and so on;
-	@echo and ^$(platform) is Win32 for 32-bit builds and x64 for x64 builds.
+	@echo found, default is $$(srcrootdir)\..\vs$$(short_vs_ver)\$$(platform),
+	@echo where $$(short_vs_ver) is 14 for VS 2015 and so on;
+	@echo and $$(platform) is Win32 for 32-bit builds and x64 for x64 builds.
+	@echo.
+	@echo BASE_INCLUDEDIR: Optional, base directory of where headers of dependencies
+	@echo can be found, default is $$(PREFIX)\include. Can be overridden with
+	@echo BOOST_INCLUDEDIR as needed.
+	@echo.
+	@echo BASE_LIBDIR: Optional, base directory of where .lib's of dependencies
+	@echo can be found, default is $$(PREFIX)\lib. Can be overridden with
+	@echo BOOST_LIBDIR as needed.
+	@echo.
+	@echo BOOST_INCLUDEDIR: Optional, directory of where where Boost C++ headers
+	@echo can be found, default is $(BASE_INCLUDEDIR)\include. You need to include,
+	@echo if any, the subdirectory for your Boost headers for your installation,
+	@echo so for Boost-1_89 for instance, you need to say
+	@echo BOOST_INCLUDEDIR=^<some_dir^>\boost-1_89.
+	@echo.
+	@echo BOOST_LIBDIR: Optional, directory of where where Boost C++ .lib's can
+	@echo be found, default is $$(BASE_LIBDIR).
+	@echo.
+	@echo BOOST_DLL: Optional, set to 1 if building against a DLL build of Boost.
 	@echo.
 	@echo STATIC: Optional, enable to build static libsigc++.  Define
 	@echo LIBSIGCXX_STATIC in the compiler flags to use the static build of
 	@echo libsigc++.
+	@echo.
+	@echo PERL, M4: Path to the PERL intepreter and the m4 utility program, if not in ^%PATH^%.
+	@echo PERL is needed for all builds and m4 is needed if building from a GIT checkout. As
+	@echo an alternative to using M4, one can use UNIX_TOOLS_BINDIR instead to point to the
+	@echo directory where m4.exe is located, such as Cygwin's or MSYS2/MSYS64's 'bin' directory,
+	@echo as other UNIXy tools may be used during code generation for a build from a GIT checkout.
 	@echo.
 	@echo ======
 	@echo A 'clean' target is supported to remove all generated files, intermediate
 	@echo object files and binaries for the specified configuration.
 	@echo.
 	@echo An 'install' target is supported to copy the build (DLLs, LIBs, along with
-	@echo the header files) to appropriate locations under ^$(PREFIX).
+	@echo the header files) to appropriate locations under $$(PREFIX).
 	@echo.
 	@echo A 'tests' target is supported to build the test programs, and a 'benchmark'
 	@echo target is supported to build the benchmarking program.  Note that the

--- a/MSVC_NMake/install.mak
+++ b/MSVC_NMake/install.mak
@@ -3,18 +3,18 @@
 
 install: all
 	@if not exist $(PREFIX)\bin\ md $(PREFIX)\bin
-	@if not exist $(PREFIX)\lib\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\include\ md $(PREFIX)\lib\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\include
-	@if not exist $(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\adaptors\lambda\ @md $(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\adaptors\lambda
-	@if not exist $(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\functors\ @md $(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\functors
-	@if not exist $(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\tuple-utils\ @md $(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\tuple-utils
-	@if "$(STATIC)" == "" copy /b $(LIBSIGC_DLL) $(PREFIX)\bin
-	@if "$(STATIC)" == "" copy /b $(LIBSIGC_DLL:.dll=.pdb) $(PREFIX)\bin
-	@copy /b $(LIBSIGC_LIB) $(PREFIX)\lib
-	@copy "..\sigc++\sigc++.h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\"
-	@for %h in ($(LIBSIGC_INT_HDRS)) do @copy "..\sigc++\%h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\%h"
-	@for %d in (..\sigc++ ..\untracked\sigc++ vs$(VSVER)\$(CFG)\$(PLAT)\sigc\sigc++) do @(for %h in ($(base_built_h)) do @if exist %d\%h copy "%d\%h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\%h")
-	@for %d in (..\sigc++ ..\untracked\sigc++ vs$(VSVER)\$(CFG)\$(PLAT)\sigc\sigc++) do @(for %h in ($(functors_built_h)) do @if exist %d\functors\%h copy "%d\functors\%h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\functors\%h")
-	@for %d in (..\sigc++ ..\untracked\sigc++ vs$(VSVER)\$(CFG)\$(PLAT)\sigc\sigc++) do @(for %h in ($(adaptors_built_h)) do @if exist %d\adaptors\%h copy "%d\adaptors\%h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\adaptors\%h")
-	@for %d in (..\sigc++ ..\untracked\sigc++ vs$(VSVER)\$(CFG)\$(PLAT)\sigc\sigc++) do @(for %h in ($(lambda_built_h)) do @if exist %d\adaptors\lambda\%h copy "%d\adaptors\lambda\%h" "$(PREFIX)\include\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\sigc++\adaptors\lambda\%h")
-	@if exist sigc++config.h copy "sigc++config.h" "$(PREFIX)\lib\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\include\"
-	@if exist ..\untracked\MSVC_NMake\sigc++config.h copy "..\untracked\MSVC_NMake\sigc++config.h" "$(PREFIX)\lib\sigc++-$(LIBSIGC_MAJOR_VERSION).$(LIBSIGC_MINOR_VERSION)\include\"
+	@if not exist $(PREFIX)\lib\sigc++-$(SIGC_SERIES)\include\ md $(PREFIX)\lib\sigc++-$(SIGC_SERIES)\include
+	@if not exist $(PREFIX)\include\sigc++-$(SIGC_SERIES)\sigc++\adaptors\lambda\ @md $(PREFIX)\include\sigc++-$(SIGC_SERIES)\sigc++\adaptors\lambda
+	@if not exist $(PREFIX)\include\sigc++-$(SIGC_SERIES)\sigc++\functors\ @md $(PREFIX)\include\sigc++-$(SIGC_SERIES)\sigc++\functors
+	@if not exist $(PREFIX)\include\sigc++-$(SIGC_SERIES)\sigc++\tuple-utils\ @md $(PREFIX)\include\sigc++-$(SIGC_SERIES)\sigc++\tuple-utils
+	@if "$(STATIC)" == "" copy /b $(SIGC_DLL) $(PREFIX)\bin
+	@if "$(STATIC)" == "" copy /b $(SIGC_DLL:.dll=.pdb) $(PREFIX)\bin
+	@copy /b $(SIGC_LIB) $(PREFIX)\lib
+	@copy "..\sigc++\sigc++.h" "$(PREFIX)\include\sigc++-$(SIGC_SERIES)\sigc++\"
+	@for %h in ($(SIGC_INT_HDRS)) do @copy "..\sigc++\%h" "$(PREFIX)\include\sigc++-$(SIGC_SERIES)\sigc++\%h"
+	@for %d in (..\sigc++ ..\untracked\sigc++ $(OUTDIR)\sigc\sigc++) do @(for %h in ($(base_built_h)) do @if exist %d\%h copy "%d\%h" "$(PREFIX)\include\sigc++-$(SIGC_SERIES)\sigc++\%h")
+	@for %d in (..\sigc++ ..\untracked\sigc++ $(OUTDIR)\sigc\sigc++) do @(for %h in ($(functors_built_h)) do @if exist %d\functors\%h copy "%d\functors\%h" "$(PREFIX)\include\sigc++-$(SIGC_SERIES)\sigc++\functors\%h")
+	@for %d in (..\sigc++ ..\untracked\sigc++ $(OUTDIR)\sigc\sigc++) do @(for %h in ($(adaptors_built_h)) do @if exist %d\adaptors\%h copy "%d\adaptors\%h" "$(PREFIX)\include\sigc++-$(SIGC_SERIES)\sigc++\adaptors\%h")
+	@for %d in (..\sigc++ ..\untracked\sigc++ $(OUTDIR)\sigc\sigc++) do @(for %h in ($(lambda_built_h)) do @if exist %d\adaptors\lambda\%h copy "%d\adaptors\lambda\%h" "$(PREFIX)\include\sigc++-$(SIGC_SERIES)\sigc++\adaptors\lambda\%h")
+	@if exist sigc++config.h copy "sigc++config.h" "$(PREFIX)\lib\sigc++-$(SIGC_SERIES)\include\"
+	@if exist ..\untracked\MSVC_NMake\sigc++config.h copy "..\untracked\MSVC_NMake\sigc++config.h" "$(PREFIX)\lib\sigc++-$(SIGC_SERIES)\include\"


### PR DESCRIPTION
Hi,

This is the 2.12 branch version of #118, which covers the items mentioned there, and also adds more flexibility in finding `m4.exe`, which is needed for this branch if building from a GIT checkout, just like what is done in the -mm libraries, by trying to check on the validity of the path passed in as `M4=...` (or whether `m4.exe` is in `%PATH%`), and giving another option `UNIX_TOOLS_BINDIR` for NMake to allow one to specify the directory where `m4.exe` resides in, so that it is not necessary to alter the `%PATH%` to build libsigc++ from a GIT checkout via NMake.

With blessings, thank you!